### PR TITLE
Updates source class logic to use an enum

### DIFF
--- a/vcf2hl7v2/common.py
+++ b/vcf2hl7v2/common.py
@@ -1,8 +1,22 @@
 import pandas as pd
 import logging
 import re
+from enum import Enum
 
 general_logger = logging.getLogger("vcf2hl7v2.general")
+
+GERMLINE = 'Germline'
+SOMATIC = 'Somatic'
+
+
+class Genomic_Source_Class(Enum):
+
+    @classmethod
+    def set_(cls):
+        return set(map(lambda c: c.value, cls))
+
+    GERMLINE = GERMLINE
+    SOMATIC = SOMATIC
 
 
 def get_allelic_state(record, ratio_ad_dp):

--- a/vcf2hl7v2/converter.py
+++ b/vcf2hl7v2/converter.py
@@ -176,7 +176,7 @@ class Converter(object):
         if not validate_seed(seed):
             raise Exception("Please provide a valid seed")
 
-        if source_class not in ["germline", "somatic"]:
+        if source_class.title() not in Genomic_Source_Class.set_():
             raise Exception(
                 'Please provide a valid Source Class ("germline" or "somatic")'
             )
@@ -186,10 +186,7 @@ class Converter(object):
         self.patient_id = patient_id
         self.ref_build = ref_build
         self.conv_region_filename = conv_region_filename
-        if source_class == 'germline':
-            self.source_class = 'LA6683-2^Germline^LN'
-        elif source_class == 'somatic':
-            self.source_class = 'LA6684-0^Somatic^LN'
+        self.source_class = source_class
         self.seed = seed
         general_logger.info("Converter class instantiated successfully")
 

--- a/vcf2hl7v2/hl7v2_helper.py
+++ b/vcf2hl7v2/hl7v2_helper.py
@@ -70,6 +70,11 @@ class _HL7V2_Helper:
         else:
             allelic_state = f'{alleles["CODE"]}^{alleles["ALLELE"].title()}^LN'
 
+        if source_class.title() == Genomic_Source_Class.GERMLINE.value:
+            source_class_value = 'LA6683-2^Germline^LN'
+        elif source_class.title() == Genomic_Source_Class.SOMATIC.value:
+            source_class_value = 'LA6684-0^Somatic^LN'
+
         a_index = f'2{get_alphabet_index(self.variant_index)}'
         _create_variant_obx_segment(
             self, obx_1=str(self.index), obx_2="ST",
@@ -119,7 +124,7 @@ class _HL7V2_Helper:
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
             obx_2="ST", obx_3="48002-0^Genomic Source Class [Type]^LN",
-            obx_4=a_index, obx_5=source_class,
+            obx_4=a_index, obx_5=source_class_value,
         )
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
@@ -144,7 +149,8 @@ class _HL7V2_Helper:
                 obx_2="CNE", obx_3="81258-6^Allelic frequency^LN",
                 obx_4=a_index, obx_5=f'{alleles["FREQUENCY"]}',
             )
-        if allelic_state is not None and 'Germline' in source_class:
+        if(allelic_state is not None and
+           source_class.title() == Genomic_Source_Class.GERMLINE.value):
             _create_variant_obx_segment(
                 self, obx_1=str(self.index),
                 obx_2="CNE", obx_3="53034-5^Allelic state^LN",


### PR DESCRIPTION
## Description

Updated the `Genomic Source Class` logic to use an `enum` instead of `strings`.

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and validated the PEP 8 formatting using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
