### PR TITLE
Adds support for qci xml, qiagen, and snpeff vcf conversion

### DIFF
--- a/vcf2hl7v2/common.py
+++ b/vcf2hl7v2/common.py
@@ -8,6 +8,60 @@ general_logger = logging.getLogger("vcf2hl7v2.general")
 GERMLINE = 'Germline'
 SOMATIC = 'Somatic'
 
+CLIN_SIG_TO_CODE = {
+    'pathogenic': 'LA6668-3',
+    'likely pathogenic': 'LA26332-9',
+    'uncertain significance': 'LA26333-7',
+    'likely benign': 'LA26334-5',
+    'benign': 'LA6675-8'
+}
+
+GENOTYPE_TO_ALLELIC_STATE = {
+    "Het": "LA6706-1^Heterozygous^LN",
+    "Hom": "LA6705-3^Homozygous^LN"
+}
+
+# Translation Impact to Molecular Consequence
+TI_TO_MC_CODE = {
+    "wild type": "LA9658-1",
+    "deletion": "LA6692-3",
+    "duplication": "LA6686-5",
+    "frameshift": "LA6694-9",
+    "initiating methionine": "LA6695-6",
+    "insertion": "LA6687-3",
+    "insertion and deletion": "LA9659-9",
+    "missense": "LA6698-0",
+    "nonsense": "LA6699-8",
+    "silent": "LA6700-4",
+    "stop codon mutation": "LA6701-2"
+}
+
+SEQUENCING_TO_CODE = {
+    "sequencing": "LA26398-0",
+    "oligo acgh": "LA26399-8",
+    "snp array": "LA26400-4",
+    "bac acgh": "LA26401-2",
+    "curated": "LA26402-0",
+    "digital array": "LA26403-8",
+    "fish": "LA26404-6",
+    "gene expression array": "LA26405-3",
+    "karyotyping": "LA26406-1",
+    "maph": "LA26407-9",
+    "maldi-tof": "LA26408-7",
+    "merging": "LA26808-8",
+    "multiple complete digestion": "LA26414-5",
+    "mlpa": "LA26415-2",
+    "optical mapping": "LA26417-8",
+    "pcr": "LA26418-6",
+    "qpcr (real-time PCR)": "LA26419-4",
+    "roma": "LA26420-2",
+    "denaturing high-pressure liquid chromatography (dhplc)": "LA26809-6",
+    "dna hybridization": "LA26810-4",
+    "computational analysis": "LA26811-2",
+    "single-stranded conformational polymorphism (sscp)": "LA26812-0",
+    "restriction fragment length polymorphism (rflp)": "LA26813-8"
+}
+
 
 class Genomic_Source_Class(Enum):
 
@@ -71,11 +125,123 @@ def get_allelic_state(record, ratio_ad_dp):
             }
 
 
+def get_variant_name_xml(variant):
+    if(is_present_xml(variant, 'transcriptchange') and
+       is_present_xml(variant.get('transcriptchange'), 'transcript') and
+       is_present_xml(variant.get('transcriptchange'), 'change') and
+       is_present_xml(variant, 'proteinchange') and
+       is_present_xml(variant.get('proteinchange'), 'change')):
+        display_name =\
+            (f'{variant.get("transcriptchange").get("transcript")}' +
+             f'({variant.get("gene")}):' +
+             f'{variant.get("transcriptchange").get("change")} ' +
+             f'({variant.get("proteinchange").get("change")})')
+    elif(is_present_xml(variant, 'transcriptchange') and
+         is_present_xml(variant.get('transcriptchange'), 'transcript') and
+         is_present_xml(variant.get('transcriptchange'), 'change') and
+         not is_present_xml(variant, 'proteinchange') and
+         not is_present_xml(variant.get('proteinchange'), 'change')):
+        display_name =\
+            (f'{variant.get("transcriptchange").get("transcript")}' +
+             f'({variant.get("gene")}):' +
+             f'{variant.get("transcriptchange").get("chnage")}')
+    else:
+        display_name =\
+            (f'{variant.get("chromosome")}:' +
+             f'{variant.get("genomicchange").get("change")}')
+    return display_name
+
+
 def extract_chrom_identifier(chrom):
     chrom = chrom.upper().replace("CHR", "")
     if chrom == "MT":
         chrom = "M"
     return chrom
+
+
+def get_spdi_representation(record, ref_seq, xml):
+    if xml:
+        return (f'{ref_seq}:{int(record.get("position")) - 1}:' +
+                f'{record.get("reference")}:{record.get("alternate")}')
+    else:
+        return (f'{ref_seq}:{record.POS - 1}:{record.REF}:' +
+                f'{"".join(list(map(str, list(record.ALT))))}')
+
+
+def get_chromosome(variant, xml_reader):
+    if not xml_reader:
+        variant.CHROM = extract_chrom_identifier(variant.CHROM)
+        return str(variant.CHROM)
+    else:
+        return str(variant.get("chromosome"))
+
+
+def get_position(variant, xml_reader):
+    if not xml_reader:
+        return int(variant.POS)
+    else:
+        return int(variant.get("position"))
+
+
+def get_reference(variant, xml_reader):
+    if not xml_reader:
+        return str(variant.REF)
+    else:
+        return str(variant.get("reference"))
+
+
+def get_alternate(variant, xml):
+    if xml:
+        return str(variant.get("alternate"))
+    else:
+        return ("".join(list(map(str, list(variant.ALT)))))
+
+
+def get_variant_display_name(record, spdi_representation, xml):
+    if xml:
+        return get_variant_name_xml(record)
+    else:
+        return spdi_representation
+
+
+def get_as_af(record, ratio_ad_dp, xml):
+    if xml:
+        allelic_state =\
+            GENOTYPE_TO_ALLELIC_STATE.get(str(record.get("genotype")))
+        allelic_frequency =\
+            (float(record.get("allelefraction")) / 100)
+    else:
+        alleles = get_allelic_state(record, ratio_ad_dp)
+        if alleles["CODE"] == '' and alleles["ALLELE"] == '':
+            allelic_state = None
+        else:
+            allelic_state =\
+                f'{alleles["CODE"]}^{alleles["ALLELE"].title()}^LN'
+        allelic_frequency = alleles["FREQUENCY"]
+
+    return allelic_state, allelic_frequency
+
+
+def validate_filename(filename):
+    pattern = r'^[\w,\s\-,/,\.]+\.(xml|vcf|vcf\.gz)$'
+    result = re.match(pattern, filename)
+    return bool(result)
+
+
+def is_xml_file(filename):
+    extension = filename.split('.')[-1]
+    if extension == 'xml':
+        return True
+    else:
+        return False
+
+
+def is_txt_file(filename):
+    extension = filename.split('.')[-1]
+    if extension == 'txt':
+        return True
+    else:
+        return False
 
 
 def validate_chrom_identifier(chrom):
@@ -129,11 +295,22 @@ def is_present(annotation, component):
 
 # The following function is used to fetch the annotations for the record
 # supplied. It returns None is there are no annotations for that record
-def get_annotations(record, annotations, spdi_representation):
+def get_annotations(record, annotations, spdi_representation, vcf_type, xml):
     if annotations is None:
-        return {'dna_change': spdi_representation,
-                'amino_acid_change': None, 'clin_sig': "not specified",
-                'phenotype': None, 'gene_studied': 'HGNC:0000^NoGene^HGNC'}
+        if xml:
+            return get_annotations_from_xml(record, spdi_representation)
+        if vcf_type is not None:
+            return get_annotations_from_vcf(
+                record, spdi_representation, vcf_type)
+        else:
+            return {'dna_change': spdi_representation,
+                    'amino_acid_change': None, 'clin_sig': "not specified",
+                    'phenotype': None, 'gene_studied': 'HGNC:0000^NoGene^HGNC',
+                    'transcript_ref_seq': None,
+                    'molecular_consequence': None,
+                    'genomic_dna_change': None, 'dna_region': None,
+                    'protein_ref_seq': None, 'db_snp_id': None,
+                    'phenotype_description': None, 'read_depth': None}
 
     annotation = annotations[
                     (annotations['CHROM'] == f'chr{record.CHROM}') &
@@ -177,10 +354,291 @@ def get_annotations(record, annotations, spdi_representation):
         else:
             gene_studied = 'HGNC:0000^NoGene^HGNC'
 
+        transcript_ref_seq = None
+        molecular_consequence = None
+        genomic_dna_change = None
+        dna_region = None
+        protein_ref_seq = None
+        db_snp_id = None
+        phenotype_description = None
+        read_depth = None
+
         return {'dna_change': dna_change,
                 'amino_acid_change': amino_acid_change,
                 'clin_sig': clin_sig, 'phenotype': phenotype,
-                'gene_studied': gene_studied}
+                'gene_studied': gene_studied,
+                'transcript_ref_seq': transcript_ref_seq,
+                'molecular_consequence': molecular_consequence,
+                'genomic_dna_change': genomic_dna_change,
+                'dna_region': dna_region,
+                'protein_ref_seq': protein_ref_seq, 'db_snp_id': db_snp_id,
+                'phenotype_description': phenotype_description,
+                'read_depth': read_depth}
+
+
+def get_annotations_from_vcf(record, spdi_representation, vcf_type):
+    if vcf_type == 'qiagen':
+        return get_annotations_from_qiagen_vcf(record, spdi_representation)
+    elif vcf_type == 'snpeff':
+        return get_annotations_from_snpeff_vcf(record, spdi_representation)
+    else:
+        return {'dna_change': spdi_representation,
+                'amino_acid_change': None, 'clin_sig': "not specified",
+                'phenotype': None, 'gene_studied': 'HGNC:0000^NoGene^HGNC',
+                'transcript_ref_seq': None,
+                'molecular_consequence': None,
+                'genomic_dna_change': None, 'dna_region': None,
+                'protein_ref_seq': None, 'db_snp_id': None,
+                'phenotype_description': None, 'read_depth': None}
+
+
+def get_annotations_from_qiagen_vcf(record, spdi_representation):
+    if('HGVS_TRANSCRIPT' in record.INFO and
+       'TRANSCRIPT_ID' in record.INFO):
+        dna_change = (f"{record.INFO['TRANSCRIPT_ID'][0]}:" +
+                      f"{record.INFO['HGVS_TRANSCRIPT'][0]}")
+    elif('HGVS_TRANSCRIPT' in record.INFO and
+         'TRANSCRIPT_ID' not in record.INFO):
+        dna_change = f"{record.INFO['HGVS_TRANSCRIPT'][0]}"
+    else:
+        dna_change = spdi_representation
+
+    if 'HGVS_PROTEIN' in record.INFO:
+        amino_acid_change = f"{record.INFO['HGVS_PROTEIN'][0]}"
+    else:
+        amino_acid_change = None
+
+    if 'CLI_ASSESSMENT' in record.INFO:
+        clin_sig = f"{record.INFO['CLI_ASSESSMENT'][0]}"
+    else:
+        clin_sig = "not specified"
+
+    if('DBSNP' in record.INFO and
+       'ING_PHENOTYPE' in record.INFO and
+       'GENE_SYMBOL' in record.INFO):
+        phenotype =\
+            (f"{record.INFO['DBSNP'][0]}^{record.INFO['ING_PHENOTYPE'][0]}" +
+             f"^{record.INFO['GENE_SYMBOL'][0]}")
+    else:
+        phenotype = None
+
+    gene_studied = 'HGNC:0000^NoGene^HGNC'
+
+    transcript_ref_seq = None
+    molecular_consequence = None
+    genomic_dna_change = None
+    dna_region = None
+    protein_ref_seq = None
+    db_snp_id = None
+    phenotype_description = None
+    read_depth = None
+
+    return {'dna_change': dna_change,
+            'amino_acid_change': amino_acid_change,
+            'clin_sig': clin_sig, 'phenotype': phenotype,
+            'gene_studied': gene_studied,
+            'transcript_ref_seq': transcript_ref_seq,
+            'molecular_consequence': molecular_consequence,
+            'genomic_dna_change': genomic_dna_change,
+            'dna_region': dna_region,
+            'protein_ref_seq': protein_ref_seq, 'db_snp_id': db_snp_id,
+            'phenotype_description': phenotype_description,
+            'read_depth': read_depth}
+
+
+def is_present_snpeff_vcf(record, index):
+    try:
+        component = record.INFO['ANN'][0].split("|")[index]
+        return True
+    except Exception as e:
+        return False
+
+
+def get_annotations_from_snpeff_vcf(record, spdi_representation):
+    if('ANN' not in record.INFO or
+       ('ANN' in record.INFO and len(record.INFO["ANN"]) == 0)):
+        return {'dna_change': spdi_representation,
+                'amino_acid_change': None, 'clin_sig': "not specified",
+                'phenotype': None, 'gene_studied': 'HGNC:0000^NoGene^HGNC',
+                'transcript_ref_seq': None,
+                'molecular_consequence': None,
+                'genomic_dna_change': None, 'dna_region': None,
+                'protein_ref_seq': None, 'db_snp_id': None,
+                'phenotype_description': None, 'read_depth': None}
+
+    if(is_present_snpeff_vcf(record, 9) and
+       is_present_snpeff_vcf(record, 6)):
+        dna_change = (f'{record.INFO["ANN"][0].split("|")[6]}:' +
+                      f'{record.INFO["ANN"][0].split("|")[9]}')
+    elif(is_present_snpeff_vcf(record, 9) and
+         not is_present_snpeff_vcf(record, 6)):
+        dna_change = f'{record.INFO["ANN"][0].split("|")[9]}'
+    else:
+        dna_change = spdi_representation
+
+    if(is_present_snpeff_vcf(record, 10) and
+       False):  # proteinrefseq
+        amino_acid_change = (f'{record.INFO["ANN"]["proteinRefSeq"][0]}:' +
+                             f'{record.INFO["ANN"][0].split("|")[10]}')
+    elif(is_present_snpeff_vcf(record, 10) and
+         not False):  # proteinrefseq
+        amino_acid_change = f'{record.INFO["ANN"][0].split("|")[10]}'
+    else:
+        amino_acid_change = None
+
+    if 'CLNSIG' in record.INFO:
+        if isinstance(record.INFO['CLNSIG'], list):
+            clin_sig = record.INFO['CLNSIG'][0]
+        else:
+            clin_sig = f"{record.INFO['CLNSIG']}"
+    else:
+        clin_sig = "not specified"
+
+    if 'CLNDNINCL' in record.INFO:
+        if isinstance(record.INFO['CLNDNINCL'], list):
+            phenotype = record.INFO['CLNDNINCL'][0]
+        else:
+            phenotype = f"{record.INFO['CLNDNINCL']}"
+    else:
+        phenotype = None
+
+    if False:  # Gene
+        gene_studied = record.INFO['GENE'][0]
+    else:
+        gene_studied = 'HGNC:0000^NoGene^HGNC'
+
+    transcript_ref_seq = None
+    molecular_consequence = None
+    genomic_dna_change = None
+    dna_region = None
+    protein_ref_seq = None
+    db_snp_id = None
+    phenotype_description = None
+    read_depth = None
+
+    return {'dna_change': dna_change,
+            'amino_acid_change': amino_acid_change,
+            'clin_sig': clin_sig, 'phenotype': phenotype,
+            'gene_studied': gene_studied,
+            'transcript_ref_seq': transcript_ref_seq,
+            'molecular_consequence': molecular_consequence,
+            'genomic_dna_change': genomic_dna_change,
+            'dna_region': dna_region,
+            'protein_ref_seq': protein_ref_seq, 'db_snp_id': db_snp_id,
+            'phenotype_description': phenotype_description,
+            'read_depth': read_depth}
+
+
+def is_present_xml(variant, component):
+    if variant is not None and variant.get(component) is not None:
+        return True
+    else:
+        return False
+
+
+def get_annotations_from_xml(variant, spdi_representation):
+    if(is_present_xml(variant, 'transcriptchange') and
+       is_present_xml(variant.get('transcriptchange'), 'change') and
+       is_present_xml(variant.get('transcriptchange'), 'transcript')):
+        dna_change = (f'{variant.get("transcriptchange").get("transcript")}:' +
+                      f'{variant.get("transcriptchange").get("change")}')
+    elif(is_present_xml(variant, 'transcriptchange') and
+         is_present_xml(variant.get('transcriptchange'), 'change') and
+         not is_present_xml(variant.get('transcriptchange'), 'transcript')):
+        dna_change = f'{variant.get("transcriptchange").get("change")}'
+    else:
+        dna_change = spdi_representation
+
+    if(is_present_xml(variant, 'proteinchange') and
+       is_present_xml(variant.get('proteinchange'), 'change') and
+       is_present_xml(variant.get('proteinchange'), 'protein')):
+        amino_acid_change =\
+            (f'{variant.get("proteinchange").get("protein")}:' +
+             f'{variant.get("proteinchange").get("change")}')
+    elif(is_present_xml(variant, 'proteinchange') and
+         is_present_xml(variant.get('proteinchange'), 'change') and
+         not is_present_xml(variant.get('proteinchange'), 'protein')):
+        amino_acid_change = f'{variant.get("proteinchange").get("change")}'
+    else:
+        amino_acid_change = None
+
+    if is_present_xml(variant, 'assessment'):
+        assessment = str(variant.get("assessment"))
+        code = CLIN_SIG_TO_CODE.get(assessment.lower())
+        clin_sig = f'{code}^{assessment}^LN'
+    else:
+        clin_sig = "not specified"
+
+    phenotype = None
+    phenotype_description = None
+
+    if is_present_xml(variant, 'gene'):
+        gene_studied = f'^{variant.get("gene")}^HGNC'
+    else:
+        gene_studied = 'HGNC:0000^NoGene^HGNC'
+
+    if(is_present_xml(variant, 'transcriptchange') and
+       is_present_xml(variant.get('transcriptchange'), 'transcript')):
+        transcript_ref_seq =\
+            (f'{variant.get("transcriptchange").get("transcript")}^' +
+             f'{variant.get("transcriptchange").get("transcript")}^RefSeq-T')
+    else:
+        transcript_ref_seq = None
+
+    if(is_present_xml(variant, "genomicchange") and
+       is_present_xml(variant.get("genomicchange"), "change")):
+        genomic_dna_change = f'{variant.get("genomicchange").get("change")}'
+    else:
+        genomic_dna_change = None
+
+    if(is_present_xml(variant, "proteinchange") and
+       is_present_xml(variant.get("proteinchange"), "translationimpact")):
+        translation_impact =\
+            str(variant.get("proteinchange").get("translationimpact"))
+        code = TI_TO_MC_CODE.get(translation_impact.lower())
+        translation_value = translation_impact
+
+        if translation_impact.lower() == "in-frame":
+            translation_impact_updated = "".join(translation_impact.split("-"))
+            variation = str(variant.get("variation")).lower()
+            if variation == "substitution":
+                variation = "insertion and deletion"
+            translation_code = " ".join(
+                [translation_impact_updated, variation])
+            translation_value = translation_code
+        molecular_consequence = f"{code}^{translation_value}^LN"
+    else:
+        molecular_consequence = None
+
+    dna_region = None
+
+    if(is_present_xml(variant, "proteinchange") and
+       is_present_xml(variant.get("proteinchange"), "protein")):
+        protein_ref_seq = f'{variant.get("proteinchange").get("protein")}'
+    else:
+        protein_ref_seq = None
+
+    if is_present_xml(variant, "dbsnp"):
+        db_snp_id = f'{variant.get("dbsnp")}^{variant.get("dbsnp")}^dbSNP'
+    else:
+        db_snp_id = None
+
+    if is_present_xml(variant, "readDepth"):
+        read_depth = f'{int(variant.get("readDepth"))}'
+    else:
+        read_depth = None
+
+    return {'dna_change': dna_change,
+            'amino_acid_change': amino_acid_change,
+            'clin_sig': clin_sig, 'phenotype': phenotype,
+            'gene_studied': gene_studied,
+            'transcript_ref_seq': transcript_ref_seq,
+            'molecular_consequence': molecular_consequence,
+            'genomic_dna_change': genomic_dna_change,
+            'dna_region': dna_region,
+            'protein_ref_seq': protein_ref_seq, 'db_snp_id': db_snp_id,
+            'phenotype_description': phenotype_description,
+            'read_depth': read_depth}
 
 
 def _error_log_allelicstate(record):

--- a/vcf2hl7v2/hl7v2_helper.py
+++ b/vcf2hl7v2/hl7v2_helper.py
@@ -10,6 +10,14 @@ def _create_variant_obx_segment(self, obx_1, obx_2, obx_3, obx_4, obx_5):
     obx.obx_3 = obx_3
     obx.obx_4 = obx_4
     obx.obx_5 = obx_5
+    if len(str(obx)) > 50:
+        prev_len =\
+            len(str(obx_1)) + len(str(obx_2)) + len(str(obx_3)) +\
+            len(str(obx_4))
+        required_len = 50 - prev_len
+        obx_5_str = str(obx_5)
+        obx_5_str = obx_5_str[:required_len]
+        obx.obx_5 = obx_5_str
     self.message.add(obx)
     self.index += 1
 
@@ -23,6 +31,28 @@ class _HL7V2_Helper:
         self.index = seed
         self.region_studied_index = 1
         self.variant_index = 1
+        self.section1_index = 1
+
+    def add_section1_components(self, xml_reader):
+        obx = hl7.Segment("OBX")
+        obx.obx_1 = str(self.index)
+        obx.obx_2 = "ST"
+        obx.obx_3 = "51967-8^Genetic Disease Assessed^UFMOLLRR"
+        obx.obx_4 = '1'
+        obx.obx_5 = f'{xml_reader.get("diagnosis")}'
+        self.message.add(obx)
+        self.index += 1
+        self.section1_index += 1
+
+    #     obx = hl7.Segment("OBX")
+    #     obx.obx_1 = str(self.index)
+    #     obx.obx_2 = "TX"
+    #     obx.obx_3 = "51968-6^Genetic Analysis Overall Interpretation^LN"
+    #     obx.obx_4 = '1'
+    #     obx.obx_5 = f'{xml_reader.get("interpretation")}'
+    #     self.message.add(obx)
+    #     self.index += 1
+    #     self.section1_index += 1
 
     def add_regionstudied_obv(self, ref_seq, reportable_query_regions):
         if reportable_query_regions.empty:
@@ -49,117 +79,178 @@ class _HL7V2_Helper:
             self.index += 1
         self.region_studied_index += 1
 
-    def add_final_region_studied_obx_segment(self):
+    def add_final_region_studied_obx_segment(self, report):
         obx = hl7.Segment("OBX")
         obx.obx_1 = str(self.index)
         obx.obx_2 = "TX"
-        obx.obx_3 = ("51968-6^Discrete variation " +
-                     "analysis overall interpretation^LN")
+        obx.obx_3 = ("51968-6^Genetic Analysis " +
+                     "Overall Interpretation^UFMOLLRR")
         obx.obx_4 = '1'
         obx.obx_5 = 'Negative'
         self.message.add(obx)
         self.final_rs_index = self.index - self.seed
         self.index += 1
 
-    def add_variant_obv(self, record,
-                        ref_seq, ratio_ad_dp, source_class, annotation_record,
-                        spdi_representation, ref_build):
-        alleles = get_allelic_state(record, ratio_ad_dp)
-        if alleles["CODE"] == '' and alleles["ALLELE"] == '':
-            allelic_state = None
-        else:
-            allelic_state = f'{alleles["CODE"]}^{alleles["ALLELE"].title()}^LN'
+        if report is not None:
+            obx = hl7.Segment("OBX")
+            obx.obx_1 = str(self.index)
+            obx.obx_2 = "TX"
+            obx.obx_3 = ("51969-4^Genetic Analysis Report^UFMOLLRR")
+            obx.obx_4 = '1'
+            report_segment = ""
+            for line in report:
+                report_segment += line.replace('\n', '').strip()
+                report_segment += " ~"
+            obx.obx_5 = report_segment
+            self.message.add(obx)
+            self.index += 1
 
-        if source_class.title() == Genomic_Source_Class.GERMLINE.value:
-            source_class_value = 'LA6683-2^Germline^LN'
-        elif source_class.title() == Genomic_Source_Class.SOMATIC.value:
-            source_class_value = 'LA6684-0^Somatic^LN'
+    def add_variant_obv(self, record, ref_seq, ratio_ad_dp, source_class,
+                        annotation_record, spdi_representation, ref_build,
+                        variant_analysis_method, xml):
+        allelic_state, allelic_frequency = get_as_af(record, ratio_ad_dp, xml)
+        variant_display_name =\
+            get_variant_display_name(record, spdi_representation, xml)
+        CHROM = get_chromosome(record, xml)
+        POS = get_position(record, xml)
+        REF = get_reference(record, xml)
+        ALT = get_alternate(record, xml)
+
+        if source_class is not None:
+            if source_class.title() == Genomic_Source_Class.GERMLINE.value:
+                source_class_value = 'LA6683-2^Germline^LN'
+            elif source_class.title() == Genomic_Source_Class.SOMATIC.value:
+                source_class_value = 'LA6684-0^Somatic^LN'
+
+        vam_obx_value =\
+            (f"{SEQUENCING_TO_CODE.get(variant_analysis_method.lower())}^" +
+             f"{variant_analysis_method}^LN")
 
         a_index = f'2{get_alphabet_index(self.variant_index)}'
         _create_variant_obx_segment(
-            self, obx_1=str(self.index), obx_2="ST",
-            obx_3="83005-9^Variant Category^LN", obx_4=a_index, obx_5="Simple",
-        )
+            self, obx_1=str(self.index), obx_2="CWE",
+            obx_3="83005-9^Variant Category^LN", obx_4=a_index,
+            obx_5="LA26801-3^Simple^LN")
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
             obx_2="ST", obx_3="47998-0^Variant Display Name^LN",
-            obx_4=a_index, obx_5=spdi_representation,
-        )
+            obx_4=a_index, obx_5=variant_display_name)
         _create_variant_obx_segment(
             self, obx_1=str(self.index), obx_2="CWE",
-            obx_3="48018-6^Gene Studied^LN", obx_4=a_index,
-            obx_5=annotation_record['gene_studied'],
-        )
+            obx_3="48018-6^Gene Studied^UFMOLLRR", obx_4=a_index,
+            obx_5=annotation_record['gene_studied'])
+        if annotation_record['transcript_ref_seq'] is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index), obx_2="CWE",
+                obx_3="51958-7^Transcript Reference Sequence^LN",
+                obx_4=a_index,
+                obx_5=annotation_record['transcript_ref_seq'])
         _create_variant_obx_segment(
             self, obx_1=str(self.index), obx_2="ST",
             obx_3="48004-6^DNA Change c.HGVS^LN",
-            obx_4=a_index, obx_5=annotation_record['dna_change'],
-        )
+            obx_4=a_index, obx_5=annotation_record['dna_change'])
         if annotation_record['amino_acid_change'] is not None:
             _create_variant_obx_segment(
                 self, obx_1=str(self.index),
                 obx_2="ST", obx_3="48005-3^Amino Acid Change p.HGVS^LN",
-                obx_4=a_index, obx_5=annotation_record['amino_acid_change'],
-            )
+                obx_4=a_index, obx_5=annotation_record['amino_acid_change'])
+        if annotation_record['molecular_consequence'] is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="CWE", obx_3="48006-1^Molecular Consequence^UFMOLLRR",
+                obx_4=a_index,
+                obx_5=annotation_record['molecular_consequence'])
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
-            obx_2="ST", obx_3="48013-7^Genomic reference sequence^LN",
-            obx_4=a_index, obx_5=f'{ref_seq}',
-        )
+            obx_2="CWE", obx_3="48013-7^Genomic reference sequence^UFMOLLRR",
+            obx_4=a_index, obx_5=f'{ref_seq}')
+        if annotation_record['genomic_dna_change'] is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="ST", obx_3="81290-9^Genomic DNA Change g.HGVS^LN",
+                obx_4=a_index, obx_5=annotation_record['genomic_dna_change'])
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
             obx_2="ST", obx_3="69547-8^Genomic ref allele^LN",
-            obx_4=a_index, obx_5=str(record.REF),
-        )
+            obx_4=a_index, obx_5=str(REF))
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
             obx_2="NR", obx_3="81254-5^Genomic allele start-end^LN",
-            obx_4=a_index, obx_5=str(record.POS),
-        )
+            obx_4=a_index, obx_5=str(POS))
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
             obx_2="ST", obx_3="69551-0^Genomic alt allele^LN",
-            obx_4=a_index, obx_5=("".join(list(map(str, list(record.ALT))))),
-        )
+            obx_4=a_index, obx_5=ALT)
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
-            obx_2="ST", obx_3="48002-0^Genomic Source Class [Type]^LN",
-            obx_4=a_index, obx_5=source_class_value,
-        )
+            obx_2="ST", obx_3="48000-4^Chromosome^LN",
+            obx_4=a_index, obx_5=CHROM)
+        if annotation_record["dna_region"] is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="ST", obx_3="47999-8^DNA Region^LN",
+                obx_4=a_index, obx_5=annotation_record["dna_region"])
+        # if annotation_record["protein_ref_seq"] is not None:
+        #     _create_variant_obx_segment(
+        #         self, obx_1=str(self.index),
+        #         obx_2="ST", obx_3="^Protein Reference Sequence^LN",
+        #         obx_4=a_index, obx_5=annotation_record["protein_ref_seq"])
+        # if annotation_record["db_snp_id"] is not None:
+        #     _create_variant_obx_segment(
+        #         self, obx_1=str(self.index),
+        #         obx_2="CWE", obx_3="81255-2^dbSNP [ID]^LN",
+        #         obx_4=a_index, obx_5=annotation_record["db_snp_id"])
+        if source_class is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="CWE", obx_3="48002-0^Genomic Source Class [Type]^LN",
+                obx_4=a_index, obx_5=source_class_value)
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
-            obx_2="ST", obx_3=("53037-8^Genetic Sequence " +
-                               "Variation Clinical Significance^LN"),
-            obx_4=a_index, obx_5=annotation_record['clin_sig'],
-        )
+            obx_2="CWE", obx_3="81304-8^Variant Analysis Method [Type]^LN",
+            obx_4=a_index,
+            obx_5=vam_obx_value)
         _create_variant_obx_segment(
             self, obx_1=str(self.index),
-            obx_2="ST", obx_3="69548-6^Genetic Variant Assessment^LN",
-            obx_4=a_index, obx_5="Present",
-        )
+            obx_2="CWE", obx_3=("53037-8^Genetic Sequence " +
+                                "Variation Clinical Significance^LN"),
+            obx_4=a_index, obx_5=annotation_record['clin_sig'])
+        _create_variant_obx_segment(
+            self, obx_1=str(self.index),
+            obx_2="CWE", obx_3="69548-6^Genetic Variant Assessment^LN",
+            obx_4=a_index, obx_5="LA9633-4^Present^LN")
         if annotation_record['phenotype'] is not None:
             _create_variant_obx_segment(
                 self, obx_1=str(self.index),
                 obx_2="CWE", obx_3="81259-4^Probable Associated Phenotype^LN",
-                obx_4=a_index, obx_5=annotation_record['phenotype'],
-            )
-        if alleles["FREQUENCY"] is not None:
-            _create_variant_obx_segment(
-                self, obx_1=str(self.index),
-                obx_2="CNE", obx_3="81258-6^Allelic frequency^LN",
-                obx_4=a_index, obx_5=f'{alleles["FREQUENCY"]}',
-            )
+                obx_4=a_index, obx_5=annotation_record['phenotype'])
+        # if annotation_record['phenotype_description'] is not None:
+        #     _create_variant_obx_segment(
+        #         self, obx_1=str(self.index),
+        #         obx_2="ST", obx_3="^Phenotype Description^LN",
+        #         obx_4=a_index,
+        #         obx_5=annotation_record['phenotype_description'])
         if(allelic_state is not None and
+           source_class is not None and
            source_class.title() == Genomic_Source_Class.GERMLINE.value):
             _create_variant_obx_segment(
                 self, obx_1=str(self.index),
-                obx_2="CNE", obx_3="53034-5^Allelic state^LN",
-                obx_4=a_index, obx_5=allelic_state,
-            )
+                obx_2="CWE", obx_3="53034-5^Allelic state^LN",
+                obx_4=a_index, obx_5=allelic_state)
+        if allelic_frequency is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="NM", obx_3="81258-6^Allelic frequency^LN",
+                obx_4=a_index, obx_5=f'{round(allelic_frequency, 2)}')
+        if annotation_record["read_depth"] is not None:
+            _create_variant_obx_segment(
+                self, obx_1=str(self.index),
+                obx_2="NM", obx_3="82121-5^Allelic Read Depth^LN",
+                obx_4=a_index, obx_5=annotation_record["read_depth"])
         self.variant_index += 1
 
     def export_hl7v2_message(self, output_filename):
-        with open(output_filename, 'w') as output_file:
+        with open(output_filename, 'w', encoding='utf-8') as output_file:
             for segment in self.message.obx:
-                output_file.write(segment.to_er7())
+                output_file.write(segment.to_er7().replace(r"\R\\", "~"))
                 output_file.write('|\n')

--- a/vcf2hl7v2/hl7v2_message_generator.py
+++ b/vcf2hl7v2/hl7v2_message_generator.py
@@ -83,15 +83,18 @@ def _fix_regions_chrom(region):
 
 def _add_record_variants(
         record, ref_seq, patientID,
-        hl7v2_helper, ratio_ad_dp, source_class, annotations, ref_build):
-    spdi_representation = (f'{ref_seq}:{record.POS - 1}:{record.REF}:' +
-                           f'{"".join(list(map(str, list(record.ALT))))}')
+        hl7v2_helper, ratio_ad_dp, source_class,
+        annotations, ref_build, vcf_type, variant_analysis_method, xml=False):
+    spdi_representation = get_spdi_representation(record, ref_seq, xml)
     annotation_record =\
-        get_annotations(record, annotations, spdi_representation)
-    if annotation_record is not None and _valid_record(record):
+        get_annotations(
+            record, annotations, spdi_representation, vcf_type, xml)
+
+    if xml or (annotation_record is not None and _valid_record(record)):
         hl7v2_helper.add_variant_obv(record, ref_seq, ratio_ad_dp,
                                      source_class, annotation_record,
-                                     spdi_representation, ref_build)
+                                     spdi_representation, ref_build,
+                                     variant_analysis_method, xml)
 
 
 def _add_region_studied(
@@ -105,9 +108,9 @@ def _add_region_studied(
 
 
 def create_region_studied_obxs(
-        vcf_reader_list,
-        ref_build, patientID, has_tabix, conversion_region, region_studied,
-        ratio_ad_dp, source_class, annotations, output_filename, hl7v2_helper):
+        vcf_reader_list, xml_reader, ref_build, patientID, has_tabix,
+        conversion_region, region_studied, ratio_ad_dp, source_class,
+        annotations, report, output_filename, hl7v2_helper):
     _fix_regions_chrom(conversion_region)
     _fix_regions_chrom(region_studied)
     if conversion_region:
@@ -116,52 +119,79 @@ def create_region_studied_obxs(
             general_logger.debug(
                 "Final Conmputed Reportable Query Regions: %s", region_studied)
     general_logger.info("Start adding the Region studied OBXs")
-    if has_tabix:
-        for chrom_index in range(1, 26):
-            chrom = _get_chrom(chrom_index)
-            ref_seq = _get_ref_seq_by_chrom(
-                ref_build, extract_chrom_identifier(chrom))
-            _add_region_studied(
-                region_studied, hl7v2_helper, chrom, ref_seq, patientID)
+    if xml_reader is None:
+        if has_tabix:
+            for chrom_index in range(1, 26):
+                chrom = _get_chrom(chrom_index)
+                ref_seq = _get_ref_seq_by_chrom(
+                    ref_build, extract_chrom_identifier(chrom))
+                _add_region_studied(
+                    region_studied, hl7v2_helper, chrom, ref_seq, patientID)
+            hl7v2_helper.add_final_region_studied_obx_segment(report)
+            return
+        else:
+            variants = vcf_reader_list
     else:
-        chrom_index = 1
-        prev_add_chrom = ""
-        for record in vcf_reader_list:
-            record.CHROM = extract_chrom_identifier(record.CHROM)
-            if(not (conversion_region and
-               conversion_region[record.CHROM].empty)):
-                if prev_add_chrom != record.CHROM and (
-                        region_studied):
+        if xml_reader.get("variant") is not None:
+            if not isinstance(xml_reader.get("variant"), list):
+                xml_reader["variant"] = [xml_reader.get("variant")]
+            variants = xml_reader.get("variant")
+        else:
+            return
+    chrom_index = 1
+    prev_add_chrom = ""
+    for variant in variants:
+        CHROM = extract_chrom_identifier(get_chromosome(variant, xml_reader))
+        if(not (conversion_region and
+           conversion_region[CHROM].empty)):
+            if prev_add_chrom != CHROM and (
+                    region_studied):
+                chrom = _get_chrom(chrom_index)
+                while prev_add_chrom != CHROM:
+                    current_ref_seq = _get_ref_seq_by_chrom(
+                        ref_build, chrom)
+                    _add_region_studied(
+                        region_studied, hl7v2_helper, chrom,
+                        current_ref_seq, patientID)
+                    prev_add_chrom = chrom
+                    chrom_index += 1
                     chrom = _get_chrom(chrom_index)
-                    while prev_add_chrom != record.CHROM:
-                        current_ref_seq = _get_ref_seq_by_chrom(
-                            ref_build, chrom)
-                        _add_region_studied(
-                            region_studied,
-                            hl7v2_helper, chrom, current_ref_seq, patientID)
-                        prev_add_chrom = chrom
-                        chrom_index += 1
-                        chrom = _get_chrom(chrom_index)
-    hl7v2_helper.add_final_region_studied_obx_segment()
+    hl7v2_helper.add_final_region_studied_obx_segment(report)
 
 
 def create_variant_obxs(
-        vcf_reader_list, vcf_reader, ref_build, patientID,
+        vcf_reader_list, vcf_reader, xml_reader, ref_build, patientID,
         has_tabix, conversion_region, ratio_ad_dp, source_class, annotations,
-        output_filename, hl7v2_helper):
+        vcf_type, variant_analysis_method, output_filename, hl7v2_helper):
     _fix_regions_chrom(conversion_region)
     general_logger.info("Start adding the Variant OBXs")
-    if has_tabix:
-        for chrom_index in range(1, 26):
-            chrom = _get_chrom(chrom_index)
-            ref_seq = _get_ref_seq_by_chrom(
-                ref_build, extract_chrom_identifier(chrom))
-            if conversion_region and not conversion_region[chrom].empty:
-                for _, row in conversion_region[chrom].df.iterrows():
+    if xml_reader is None:
+        if has_tabix:
+            for chrom_index in range(1, 26):
+                chrom = _get_chrom(chrom_index)
+                ref_seq = _get_ref_seq_by_chrom(
+                    ref_build, extract_chrom_identifier(chrom))
+                if conversion_region and not conversion_region[chrom].empty:
+                    for _, row in conversion_region[chrom].df.iterrows():
+                        vcf_iterator = None
+                        try:
+                            vcf_iterator = vcf_reader.fetch(
+                                chrom, int(row['Start']), int(row['End']))
+                        except ValueError:
+                            pass
+                        if vcf_iterator:
+                            for record in vcf_iterator:
+                                record.CHROM = extract_chrom_identifier(
+                                    record.CHROM)
+                                _add_record_variants(
+                                    record, ref_seq, patientID, hl7v2_helper,
+                                    ratio_ad_dp, source_class, annotations,
+                                    ref_build, vcf_type,
+                                    variant_analysis_method)
+                elif not conversion_region:
                     vcf_iterator = None
                     try:
-                        vcf_iterator = vcf_reader.fetch(
-                            chrom, int(row['Start']), int(row['End']))
+                        vcf_iterator = vcf_reader.fetch(chrom)
                     except ValueError:
                         pass
                     if vcf_iterator:
@@ -169,61 +199,63 @@ def create_variant_obxs(
                             record.CHROM = extract_chrom_identifier(
                                 record.CHROM)
                             _add_record_variants(
-                                record,
-                                ref_seq, patientID, hl7v2_helper, ratio_ad_dp,
-                                source_class, annotations, ref_build
-                            )
-            elif not conversion_region:
-                vcf_iterator = None
-                try:
-                    vcf_iterator = vcf_reader.fetch(chrom)
-                except ValueError:
-                    pass
-                if vcf_iterator:
-                    for record in vcf_iterator:
-                        record.CHROM = extract_chrom_identifier(
-                            record.CHROM)
-                        _add_record_variants(
-                            record, ref_seq, patientID, hl7v2_helper,
-                            ratio_ad_dp, source_class, annotations, ref_build
-                        )
+                                record, ref_seq, patientID, hl7v2_helper,
+                                ratio_ad_dp, source_class,
+                                annotations, ref_build, vcf_type,
+                                variant_analysis_method)
+            return
+        else:
+            variants = vcf_reader_list
     else:
-        for record in vcf_reader_list:
-            record.CHROM = extract_chrom_identifier(record.CHROM)
-            if(not (conversion_region and
-               conversion_region[record.CHROM].empty)):
-                ref_seq = _get_ref_seq_by_chrom(ref_build, record.CHROM)
-                end = record.POS + len(record.REF) - 1
-                if(not conversion_region or
-                   conversion_region[
-                        record.CHROM, record.POS - 1: end
-                   ].empty is False):
-                    _add_record_variants(
-                        record, ref_seq, patientID, hl7v2_helper,
-                        ratio_ad_dp, source_class, annotations, ref_build
-                    )
+        if xml_reader.get("variant") is not None:
+            if not isinstance(xml_reader.get("variant"), list):
+                xml_reader["variant"] = [xml_reader.get("variant")]
+                print(xml_reader["variant"])
+            variants = xml_reader.get("variant")
+        else:
+            return
+
+    for variant in variants:
+        CHROM = extract_chrom_identifier(get_chromosome(variant, xml_reader))
+        if(not (conversion_region and
+           conversion_region[CHROM].empty)):
+            ref_seq = _get_ref_seq_by_chrom(ref_build, CHROM)
+            POS = get_position(variant, xml_reader)
+            REF = get_reference(variant, xml_reader)
+            end = POS + len(REF) - 1
+            if(not conversion_region or
+               conversion_region[CHROM, POS - 1: end].empty is False):
+                _add_record_variants(
+                    variant, ref_seq, patientID, hl7v2_helper,
+                    ratio_ad_dp, source_class,
+                    annotations, ref_build, vcf_type,
+                    variant_analysis_method, xml_reader is not None)
 
 
 def _get_hl7v2_message(
-        vcf_reader_list, vcf_reader,
-        ref_build, patientID, has_tabix, conversion_region, source_class,
-        region_studied, ratio_ad_dp, annotations, seed, output_filename):
+        vcf_reader, xml_reader, ref_build, patientID, has_tabix,
+        conversion_region, source_class, region_studied,
+        ratio_ad_dp, annotations, seed, vcf_type,
+        variant_analysis_method, report, output_filename):
     hl7v2_helper = _HL7V2_Helper(patientID, seed)
     general_logger.debug("Finished Initializing empty HL7V2 message")
+    vcf_reader_list = list(vcf_reader) if vcf_reader else []
     create_region_studied_obxs(
-        vcf_reader_list,
-        ref_build, patientID, has_tabix, conversion_region, region_studied,
-        ratio_ad_dp, source_class, annotations, output_filename, hl7v2_helper
-    )
+        vcf_reader_list, xml_reader, ref_build, patientID, has_tabix,
+        conversion_region, region_studied, ratio_ad_dp, source_class,
+        annotations, report, output_filename, hl7v2_helper)
+    if xml_reader is not None:
+        hl7v2_helper.add_section1_components(xml_reader)
     create_variant_obxs(
-        vcf_reader_list, vcf_reader, ref_build, patientID,
+        vcf_reader_list, vcf_reader, xml_reader, ref_build, patientID,
         has_tabix, conversion_region, ratio_ad_dp, source_class,
-        annotations, output_filename, hl7v2_helper
-    )
-    if (hl7v2_helper.index + seed - hl7v2_helper.final_rs_index) > 1:
+        annotations, vcf_type, variant_analysis_method, output_filename,
+        hl7v2_helper)
+    if hl7v2_helper.message.obx[-1].obx_4[0].value[0] == "2":
         hl7v2_helper.message.obx[hl7v2_helper.final_rs_index].obx_5 =\
             'Positive'
     general_logger.info(
         f'Export the HL7V2 message object to the file {output_filename}')
     hl7v2_helper.export_hl7v2_message(output_filename)
     general_logger.info("Completed conversion")
+    return hl7v2_helper.message

--- a/vcf2hl7v2/test/expected_NB6TK328.txt
+++ b/vcf2hl7v2/test/expected_NB6TK328.txt
@@ -23,74 +23,84 @@ OBX|5021|NR|51959-5^Range(s) of DNA sequence examined^LN|1j.a|1204798^1229435|
 OBX|5022|NR|51959-5^Range(s) of DNA sequence examined^LN|1j.b|11088361^11134830|
 OBX|5023|NR|51959-5^Range(s) of DNA sequence examined^LN|1j.c|38432699^38588564|
 OBX|5024|NR|51959-5^Range(s) of DNA sequence examined^LN|1j.d|55150766^55158732|
-OBX|5025|TX|51968-6^Discrete variation analysis overall interpretation^LN|1|Positive|
-OBX|5026|ST|83005-9^Variant Category^LN|2a|Simple|
+OBX|5025|TX|51968-6^Genetic Analysis Overall Interpretation^UFMOLLRR|1|Positive|
+OBX|5026|CWE|83005-9^Variant Category^LN|2a|LA26801-3^Simple^LN|
 OBX|5027|ST|47998-0^Variant Display Name^LN|2a|NC_000005.10:112841058:T:A|
-OBX|5028|CWE|48018-6^Gene Studied^LN|2a|HGNC:583^APC^HGNC|
-OBX|5029|ST|48004-6^DNA Change c.HGVS^LN|2a|NM_001127510.3:c.5465T>A|
-OBX|5030|ST|48005-3^Amino Acid Change p.HGVS^LN|2a|p.Val1822Asp|
-OBX|5031|ST|48013-7^Genomic reference sequence^LN|2a|NC_000005.10|
+OBX|5028|CWE|48018-6^Gene Studied^UFMOLLRR|2a|HGNC:583^APC^HGNC|
+OBX|5029|CWE|48004-6^DNA Change c.HGVS^LN|2a|NM_001127510.3:c.5465T>A|
+OBX|5030|CWE|48005-3^Amino Acid Change p.HGVS^LN|2a|p.Val1822Asp|
+OBX|5031|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2a|NC_000005.10|
 OBX|5032|ST|69547-8^Genomic ref allele^LN|2a|T|
 OBX|5033|NR|81254-5^Genomic allele start-end^LN|2a|112841059|
 OBX|5034|ST|69551-0^Genomic alt allele^LN|2a|A|
-OBX|5035|ST|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
-OBX|5036|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|Benign|
-OBX|5037|ST|69548-6^Genetic Variant Assessment^LN|2a|Present|
-OBX|5038|CWE|81259-4^Probable Associated Phenotype^LN|2a|72900001^Familial multiple polyposis syndrome^SCT|
-OBX|5039|CNE|53034-5^Allelic state^LN|2a|LA6705-3^Homozygous^LN|
-OBX|5040|ST|83005-9^Variant Category^LN|2b|Simple|
-OBX|5041|ST|47998-0^Variant Display Name^LN|2b|NC_000011.10:47348489:T:C|
-OBX|5042|CWE|48018-6^Gene Studied^LN|2b|HGNC:7551^MYBPC3^HGNC|
-OBX|5043|ST|48004-6^DNA Change c.HGVS^LN|2b|NM_000256.3:c.706A>G|
-OBX|5044|ST|48005-3^Amino Acid Change p.HGVS^LN|2b|p.Ser236Gly|
-OBX|5045|ST|48013-7^Genomic reference sequence^LN|2b|NC_000011.10|
-OBX|5046|ST|69547-8^Genomic ref allele^LN|2b|T|
-OBX|5047|NR|81254-5^Genomic allele start-end^LN|2b|47348490|
-OBX|5048|ST|69551-0^Genomic alt allele^LN|2b|C|
-OBX|5049|ST|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
-OBX|5050|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|Likely benign|
-OBX|5051|ST|69548-6^Genetic Variant Assessment^LN|2b|Present|
-OBX|5052|CWE|81259-4^Probable Associated Phenotype^LN|2b|35728003^Familial cardiomyopathy^SCT|
-OBX|5053|CNE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
-OBX|5054|ST|83005-9^Variant Category^LN|2c|Simple|
-OBX|5055|ST|47998-0^Variant Display Name^LN|2c|NC_000011.10:64804545:T:C|
-OBX|5056|CWE|48018-6^Gene Studied^LN|2c|HGNC:7010^MEN1^HGNC|
-OBX|5057|ST|48004-6^DNA Change c.HGVS^LN|2c|NM_130800.2:c.1516A>G|
-OBX|5058|ST|48005-3^Amino Acid Change p.HGVS^LN|2c|p.Thr506Ala|
-OBX|5059|ST|48013-7^Genomic reference sequence^LN|2c|NC_000011.10|
-OBX|5060|ST|69547-8^Genomic ref allele^LN|2c|T|
-OBX|5061|NR|81254-5^Genomic allele start-end^LN|2c|64804546|
-OBX|5062|ST|69551-0^Genomic alt allele^LN|2c|C|
-OBX|5063|ST|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
-OBX|5064|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|Benign|
-OBX|5065|ST|69548-6^Genetic Variant Assessment^LN|2c|Present|
-OBX|5066|CWE|81259-4^Probable Associated Phenotype^LN|2c|30664006^Multiple endocrine neoplasia, type 1^SCT|
-OBX|5067|CNE|53034-5^Allelic state^LN|2c|LA6705-3^Homozygous^LN|
-OBX|5068|ST|83005-9^Variant Category^LN|2d|Simple|
-OBX|5069|ST|47998-0^Variant Display Name^LN|2d|NC_000013.11:32355249:T:C|
-OBX|5070|CWE|48018-6^Gene Studied^LN|2d|HGNC:1101^BRCA2^HGNC|
-OBX|5071|ST|48004-6^DNA Change c.HGVS^LN|2d|NM_000059.4:c.7397T>C|
-OBX|5072|ST|48005-3^Amino Acid Change p.HGVS^LN|2d|p.Val2466Ala|
-OBX|5073|ST|48013-7^Genomic reference sequence^LN|2d|NC_000013.11|
-OBX|5074|ST|69547-8^Genomic ref allele^LN|2d|T|
-OBX|5075|NR|81254-5^Genomic allele start-end^LN|2d|32355250|
-OBX|5076|ST|69551-0^Genomic alt allele^LN|2d|C|
-OBX|5077|ST|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
-OBX|5078|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|Benign|
-OBX|5079|ST|69548-6^Genetic Variant Assessment^LN|2d|Present|
-OBX|5080|CWE|81259-4^Probable Associated Phenotype^LN|2d|718220008^Hereditary breast and ovarian cancer syndrome^SCT|
-OBX|5081|CNE|53034-5^Allelic state^LN|2d|LA6705-3^Homozygous^LN|
-OBX|5082|ST|83005-9^Variant Category^LN|2e|Simple|
-OBX|5083|ST|47998-0^Variant Display Name^LN|2e|NC_000019.10:38499669:C:T|
-OBX|5084|CWE|48018-6^Gene Studied^LN|2e|HGNC:10483^RYR1^HGNC|
-OBX|5085|ST|48004-6^DNA Change c.HGVS^LN|2e|NM_001042723.2:c.7063C>T|
-OBX|5086|ST|48005-3^Amino Acid Change p.HGVS^LN|2e|p.Arg2355Trp|
-OBX|5087|ST|48013-7^Genomic reference sequence^LN|2e|NC_000019.10|
-OBX|5088|ST|69547-8^Genomic ref allele^LN|2e|C|
-OBX|5089|NR|81254-5^Genomic allele start-end^LN|2e|38499670|
-OBX|5090|ST|69551-0^Genomic alt allele^LN|2e|T|
-OBX|5091|ST|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
-OBX|5092|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|Pathogenic|
-OBX|5093|ST|69548-6^Genetic Variant Assessment^LN|2e|Present|
-OBX|5094|CWE|81259-4^Probable Associated Phenotype^LN|2e|405501007^Malignant hyperthermia^SCT|
-OBX|5095|CNE|53034-5^Allelic state^LN|2e|LA6706-1^Heterozygous^LN|
+OBX|5035|ST|48000-4^Chromosome^LN|2a|5|
+OBX|5036|CWE|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
+OBX|5037|CWE|81304-8^Variant Analysis Method [Type]^LN|2a|LA26398-0^Sequencing^LN|
+OBX|5038|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|Benign|
+OBX|5039|CWE|69548-6^Genetic Variant Assessment^LN|2a|LA9633-4^Present^LN|
+OBX|5040|CWE|81259-4^Probable Associated Phenotype^LN|2a|72900001^Familial multiple polyposis syndrome^SCT|
+OBX|5041|CWE|53034-5^Allelic state^LN|2a|LA6705-3^Homozygous^LN|
+OBX|5042|CWE|83005-9^Variant Category^LN|2b|LA26801-3^Simple^LN|
+OBX|5043|ST|47998-0^Variant Display Name^LN|2b|NC_000011.10:47348489:T:C|
+OBX|5044|CWE|48018-6^Gene Studied^UFMOLLRR|2b|HGNC:7551^MYBPC3^HGNC|
+OBX|5045|CWE|48004-6^DNA Change c.HGVS^LN|2b|NM_000256.3:c.706A>G|
+OBX|5046|CWE|48005-3^Amino Acid Change p.HGVS^LN|2b|p.Ser236Gly|
+OBX|5047|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2b|NC_000011.10|
+OBX|5048|ST|69547-8^Genomic ref allele^LN|2b|T|
+OBX|5049|NR|81254-5^Genomic allele start-end^LN|2b|47348490|
+OBX|5050|ST|69551-0^Genomic alt allele^LN|2b|C|
+OBX|5051|ST|48000-4^Chromosome^LN|2b|11|
+OBX|5052|CWE|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
+OBX|5053|CWE|81304-8^Variant Analysis Method [Type]^LN|2b|LA26398-0^Sequencing^LN|
+OBX|5054|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|Likely benign|
+OBX|5055|CWE|69548-6^Genetic Variant Assessment^LN|2b|LA9633-4^Present^LN|
+OBX|5056|CWE|81259-4^Probable Associated Phenotype^LN|2b|35728003^Familial cardiomyopathy^SCT|
+OBX|5057|CWE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
+OBX|5058|CWE|83005-9^Variant Category^LN|2c|LA26801-3^Simple^LN|
+OBX|5059|ST|47998-0^Variant Display Name^LN|2c|NC_000011.10:64804545:T:C|
+OBX|5060|CWE|48018-6^Gene Studied^UFMOLLRR|2c|HGNC:7010^MEN1^HGNC|
+OBX|5061|CWE|48004-6^DNA Change c.HGVS^LN|2c|NM_130800.2:c.1516A>G|
+OBX|5062|CWE|48005-3^Amino Acid Change p.HGVS^LN|2c|p.Thr506Ala|
+OBX|5063|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2c|NC_000011.10|
+OBX|5064|ST|69547-8^Genomic ref allele^LN|2c|T|
+OBX|5065|NR|81254-5^Genomic allele start-end^LN|2c|64804546|
+OBX|5066|ST|69551-0^Genomic alt allele^LN|2c|C|
+OBX|5067|ST|48000-4^Chromosome^LN|2c|11|
+OBX|5068|CWE|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
+OBX|5069|CWE|81304-8^Variant Analysis Method [Type]^LN|2c|LA26398-0^Sequencing^LN|
+OBX|5070|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|Benign|
+OBX|5071|CWE|69548-6^Genetic Variant Assessment^LN|2c|LA9633-4^Present^LN|
+OBX|5072|CWE|81259-4^Probable Associated Phenotype^LN|2c|30664006^Multiple endocrine neoplasia, type 1^SCT|
+OBX|5073|CWE|53034-5^Allelic state^LN|2c|LA6705-3^Homozygous^LN|
+OBX|5074|CWE|83005-9^Variant Category^LN|2d|LA26801-3^Simple^LN|
+OBX|5075|ST|47998-0^Variant Display Name^LN|2d|NC_000013.11:32355249:T:C|
+OBX|5076|CWE|48018-6^Gene Studied^UFMOLLRR|2d|HGNC:1101^BRCA2^HGNC|
+OBX|5077|CWE|48004-6^DNA Change c.HGVS^LN|2d|NM_000059.4:c.7397T>C|
+OBX|5078|CWE|48005-3^Amino Acid Change p.HGVS^LN|2d|p.Val2466Ala|
+OBX|5079|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2d|NC_000013.11|
+OBX|5080|ST|69547-8^Genomic ref allele^LN|2d|T|
+OBX|5081|NR|81254-5^Genomic allele start-end^LN|2d|32355250|
+OBX|5082|ST|69551-0^Genomic alt allele^LN|2d|C|
+OBX|5083|ST|48000-4^Chromosome^LN|2d|13|
+OBX|5084|CWE|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
+OBX|5085|CWE|81304-8^Variant Analysis Method [Type]^LN|2d|LA26398-0^Sequencing^LN|
+OBX|5086|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|Benign|
+OBX|5087|CWE|69548-6^Genetic Variant Assessment^LN|2d|LA9633-4^Present^LN|
+OBX|5088|CWE|81259-4^Probable Associated Phenotype^LN|2d|718220008^Hereditary breast and ovarian cancer syndrome^SCT|
+OBX|5089|CWE|53034-5^Allelic state^LN|2d|LA6705-3^Homozygous^LN|
+OBX|5090|CWE|83005-9^Variant Category^LN|2e|LA26801-3^Simple^LN|
+OBX|5091|ST|47998-0^Variant Display Name^LN|2e|NC_000019.10:38499669:C:T|
+OBX|5092|CWE|48018-6^Gene Studied^UFMOLLRR|2e|HGNC:10483^RYR1^HGNC|
+OBX|5093|CWE|48004-6^DNA Change c.HGVS^LN|2e|NM_001042723.2:c.7063C>T|
+OBX|5094|CWE|48005-3^Amino Acid Change p.HGVS^LN|2e|p.Arg2355Trp|
+OBX|5095|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2e|NC_000019.10|
+OBX|5096|ST|69547-8^Genomic ref allele^LN|2e|C|
+OBX|5097|NR|81254-5^Genomic allele start-end^LN|2e|38499670|
+OBX|5098|ST|69551-0^Genomic alt allele^LN|2e|T|
+OBX|5099|ST|48000-4^Chromosome^LN|2e|19|
+OBX|5100|CWE|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
+OBX|5101|CWE|81304-8^Variant Analysis Method [Type]^LN|2e|LA26398-0^Sequencing^LN|
+OBX|5102|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|Pathogenic|
+OBX|5103|CWE|69548-6^Genetic Variant Assessment^LN|2e|LA9633-4^Present^LN|
+OBX|5104|CWE|81259-4^Probable Associated Phenotype^LN|2e|405501007^Malignant hyperthermia^SCT|
+OBX|5105|CWE|53034-5^Allelic state^LN|2e|LA6706-1^Heterozygous^LN|

--- a/vcf2hl7v2/test/expected_example1_with_patient.txt
+++ b/vcf2hl7v2/test/expected_example1_with_patient.txt
@@ -1,97 +1,113 @@
-OBX|1000|TX|51968-6^Discrete variation analysis overall interpretation^LN|1|Positive|
-OBX|1001|ST|83005-9^Variant Category^LN|2a|Simple|
+OBX|1000|TX|51968-6^Genetic Analysis Overall Interpretation^UFMOLLRR|1|Positive|
+OBX|1001|CWE|83005-9^Variant Category^LN|2a|LA26801-3^Simple^LN|
 OBX|1002|ST|47998-0^Variant Display Name^LN|2a|NC_000001.10:14:.:G|
-OBX|1003|CWE|48018-6^Gene Studied^LN|2a|HGNC:0000^NoGene^HGNC|
-OBX|1004|ST|48004-6^DNA Change c.HGVS^LN|2a|NC_000001.10:14:.:G|
-OBX|1005|ST|48013-7^Genomic reference sequence^LN|2a|NC_000001.10|
+OBX|1003|CWE|48018-6^Gene Studied^UFMOLLRR|2a|HGNC:0000^NoGene^HGNC|
+OBX|1004|CWE|48004-6^DNA Change c.HGVS^LN|2a|NC_000001.10:14:.:G|
+OBX|1005|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2a|NC_000001.10|
 OBX|1006|ST|69547-8^Genomic ref allele^LN|2a|.|
 OBX|1007|NR|81254-5^Genomic allele start-end^LN|2a|15|
 OBX|1008|ST|69551-0^Genomic alt allele^LN|2a|G|
-OBX|1009|ST|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
-OBX|1010|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
-OBX|1011|ST|69548-6^Genetic Variant Assessment^LN|2a|Present|
-OBX|1012|CNE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
-OBX|1013|ST|83005-9^Variant Category^LN|2b|Simple|
-OBX|1014|ST|47998-0^Variant Display Name^LN|2b|NC_000001.10:15:A,T:G|
-OBX|1015|CWE|48018-6^Gene Studied^LN|2b|HGNC:0000^NoGene^HGNC|
-OBX|1016|ST|48004-6^DNA Change c.HGVS^LN|2b|NC_000001.10:15:A,T:G|
-OBX|1017|ST|48013-7^Genomic reference sequence^LN|2b|NC_000001.10|
-OBX|1018|ST|69547-8^Genomic ref allele^LN|2b|A,T|
-OBX|1019|NR|81254-5^Genomic allele start-end^LN|2b|16|
-OBX|1020|ST|69551-0^Genomic alt allele^LN|2b|G|
-OBX|1021|ST|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
-OBX|1022|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
-OBX|1023|ST|69548-6^Genetic Variant Assessment^LN|2b|Present|
-OBX|1024|CNE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
-OBX|1025|ST|83005-9^Variant Category^LN|2c|Simple|
-OBX|1026|ST|47998-0^Variant Display Name^LN|2c|NC_000001.10:19::G|
-OBX|1027|CWE|48018-6^Gene Studied^LN|2c|HGNC:0000^NoGene^HGNC|
-OBX|1028|ST|48004-6^DNA Change c.HGVS^LN|2c|NC_000001.10:19::G|
-OBX|1029|ST|48013-7^Genomic reference sequence^LN|2c|NC_000001.10|
-OBX|1030|ST|69547-8^Genomic ref allele^LN|2c||
-OBX|1031|NR|81254-5^Genomic allele start-end^LN|2c|20|
-OBX|1032|ST|69551-0^Genomic alt allele^LN|2c|G|
-OBX|1033|ST|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
-OBX|1034|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
-OBX|1035|ST|69548-6^Genetic Variant Assessment^LN|2c|Present|
-OBX|1036|CNE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
-OBX|1037|ST|83005-9^Variant Category^LN|2d|Simple|
-OBX|1038|ST|47998-0^Variant Display Name^LN|2d|NC_000001.10:300:A:G|
-OBX|1039|CWE|48018-6^Gene Studied^LN|2d|HGNC:0000^NoGene^HGNC|
-OBX|1040|ST|48004-6^DNA Change c.HGVS^LN|2d|NC_000001.10:300:A:G|
-OBX|1041|ST|48013-7^Genomic reference sequence^LN|2d|NC_000001.10|
-OBX|1042|ST|69547-8^Genomic ref allele^LN|2d|A|
-OBX|1043|NR|81254-5^Genomic allele start-end^LN|2d|301|
-OBX|1044|ST|69551-0^Genomic alt allele^LN|2d|G|
-OBX|1045|ST|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
-OBX|1046|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
-OBX|1047|ST|69548-6^Genetic Variant Assessment^LN|2d|Present|
-OBX|1048|CNE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
-OBX|1049|ST|83005-9^Variant Category^LN|2e|Simple|
-OBX|1050|ST|47998-0^Variant Display Name^LN|2e|NC_000001.10:399:A:G|
-OBX|1051|CWE|48018-6^Gene Studied^LN|2e|HGNC:0000^NoGene^HGNC|
-OBX|1052|ST|48004-6^DNA Change c.HGVS^LN|2e|NC_000001.10:399:A:G|
-OBX|1053|ST|48013-7^Genomic reference sequence^LN|2e|NC_000001.10|
-OBX|1054|ST|69547-8^Genomic ref allele^LN|2e|A|
-OBX|1055|NR|81254-5^Genomic allele start-end^LN|2e|400|
-OBX|1056|ST|69551-0^Genomic alt allele^LN|2e|G|
-OBX|1057|ST|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
-OBX|1058|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
-OBX|1059|ST|69548-6^Genetic Variant Assessment^LN|2e|Present|
-OBX|1060|CNE|53034-5^Allelic state^LN|2e|LA6705-3^Homozygous^LN|
-OBX|1061|ST|83005-9^Variant Category^LN|2f|Simple|
-OBX|1062|ST|47998-0^Variant Display Name^LN|2f|NC_000001.10:499:A:G|
-OBX|1063|CWE|48018-6^Gene Studied^LN|2f|HGNC:0000^NoGene^HGNC|
-OBX|1064|ST|48004-6^DNA Change c.HGVS^LN|2f|NC_000001.10:499:A:G|
-OBX|1065|ST|48013-7^Genomic reference sequence^LN|2f|NC_000001.10|
-OBX|1066|ST|69547-8^Genomic ref allele^LN|2f|A|
-OBX|1067|NR|81254-5^Genomic allele start-end^LN|2f|500|
-OBX|1068|ST|69551-0^Genomic alt allele^LN|2f|G|
-OBX|1069|ST|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
-OBX|1070|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
-OBX|1071|ST|69548-6^Genetic Variant Assessment^LN|2f|Present|
-OBX|1072|CNE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|
-OBX|1073|ST|83005-9^Variant Category^LN|2g|Simple|
-OBX|1074|ST|47998-0^Variant Display Name^LN|2g|NC_000001.10:599:A:G|
-OBX|1075|CWE|48018-6^Gene Studied^LN|2g|HGNC:0000^NoGene^HGNC|
-OBX|1076|ST|48004-6^DNA Change c.HGVS^LN|2g|NC_000001.10:599:A:G|
-OBX|1077|ST|48013-7^Genomic reference sequence^LN|2g|NC_000001.10|
-OBX|1078|ST|69547-8^Genomic ref allele^LN|2g|A|
-OBX|1079|NR|81254-5^Genomic allele start-end^LN|2g|600|
-OBX|1080|ST|69551-0^Genomic alt allele^LN|2g|G|
-OBX|1081|ST|48002-0^Genomic Source Class [Type]^LN|2g|LA6683-2^Germline^LN|
-OBX|1082|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2g|not specified|
-OBX|1083|ST|69548-6^Genetic Variant Assessment^LN|2g|Present|
-OBX|1084|CNE|53034-5^Allelic state^LN|2g|LA6706-1^Heterozygous^LN|
-OBX|1085|ST|83005-9^Variant Category^LN|2h|Simple|
-OBX|1086|ST|47998-0^Variant Display Name^LN|2h|NC_000001.10:699:A:G|
-OBX|1087|CWE|48018-6^Gene Studied^LN|2h|HGNC:0000^NoGene^HGNC|
-OBX|1088|ST|48004-6^DNA Change c.HGVS^LN|2h|NC_000001.10:699:A:G|
-OBX|1089|ST|48013-7^Genomic reference sequence^LN|2h|NC_000001.10|
-OBX|1090|ST|69547-8^Genomic ref allele^LN|2h|A|
-OBX|1091|NR|81254-5^Genomic allele start-end^LN|2h|700|
-OBX|1092|ST|69551-0^Genomic alt allele^LN|2h|G|
-OBX|1093|ST|48002-0^Genomic Source Class [Type]^LN|2h|LA6683-2^Germline^LN|
-OBX|1094|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2h|not specified|
-OBX|1095|ST|69548-6^Genetic Variant Assessment^LN|2h|Present|
-OBX|1096|CNE|53034-5^Allelic state^LN|2h|LA6706-1^Heterozygous^LN|
+OBX|1009|ST|48000-4^Chromosome^LN|2a|1|
+OBX|1010|CWE|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
+OBX|1011|CWE|81304-8^Variant Analysis Method [Type]^LN|2a|LA26398-0^Sequencing^LN|
+OBX|1012|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
+OBX|1013|CWE|69548-6^Genetic Variant Assessment^LN|2a|LA9633-4^Present^LN|
+OBX|1014|CWE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
+OBX|1015|CWE|83005-9^Variant Category^LN|2b|LA26801-3^Simple^LN|
+OBX|1016|ST|47998-0^Variant Display Name^LN|2b|NC_000001.10:15:A,T:G|
+OBX|1017|CWE|48018-6^Gene Studied^UFMOLLRR|2b|HGNC:0000^NoGene^HGNC|
+OBX|1018|CWE|48004-6^DNA Change c.HGVS^LN|2b|NC_000001.10:15:A,T:G|
+OBX|1019|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2b|NC_000001.10|
+OBX|1020|ST|69547-8^Genomic ref allele^LN|2b|A,T|
+OBX|1021|NR|81254-5^Genomic allele start-end^LN|2b|16|
+OBX|1022|ST|69551-0^Genomic alt allele^LN|2b|G|
+OBX|1023|ST|48000-4^Chromosome^LN|2b|1|
+OBX|1024|CWE|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
+OBX|1025|CWE|81304-8^Variant Analysis Method [Type]^LN|2b|LA26398-0^Sequencing^LN|
+OBX|1026|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
+OBX|1027|CWE|69548-6^Genetic Variant Assessment^LN|2b|LA9633-4^Present^LN|
+OBX|1028|CWE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
+OBX|1029|CWE|83005-9^Variant Category^LN|2c|LA26801-3^Simple^LN|
+OBX|1030|ST|47998-0^Variant Display Name^LN|2c|NC_000001.10:19::G|
+OBX|1031|CWE|48018-6^Gene Studied^UFMOLLRR|2c|HGNC:0000^NoGene^HGNC|
+OBX|1032|CWE|48004-6^DNA Change c.HGVS^LN|2c|NC_000001.10:19::G|
+OBX|1033|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2c|NC_000001.10|
+OBX|1034|ST|69547-8^Genomic ref allele^LN|2c||
+OBX|1035|NR|81254-5^Genomic allele start-end^LN|2c|20|
+OBX|1036|ST|69551-0^Genomic alt allele^LN|2c|G|
+OBX|1037|ST|48000-4^Chromosome^LN|2c|1|
+OBX|1038|CWE|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
+OBX|1039|CWE|81304-8^Variant Analysis Method [Type]^LN|2c|LA26398-0^Sequencing^LN|
+OBX|1040|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
+OBX|1041|CWE|69548-6^Genetic Variant Assessment^LN|2c|LA9633-4^Present^LN|
+OBX|1042|CWE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
+OBX|1043|CWE|83005-9^Variant Category^LN|2d|LA26801-3^Simple^LN|
+OBX|1044|ST|47998-0^Variant Display Name^LN|2d|NC_000001.10:300:A:G|
+OBX|1045|CWE|48018-6^Gene Studied^UFMOLLRR|2d|HGNC:0000^NoGene^HGNC|
+OBX|1046|CWE|48004-6^DNA Change c.HGVS^LN|2d|NC_000001.10:300:A:G|
+OBX|1047|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2d|NC_000001.10|
+OBX|1048|ST|69547-8^Genomic ref allele^LN|2d|A|
+OBX|1049|NR|81254-5^Genomic allele start-end^LN|2d|301|
+OBX|1050|ST|69551-0^Genomic alt allele^LN|2d|G|
+OBX|1051|ST|48000-4^Chromosome^LN|2d|1|
+OBX|1052|CWE|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
+OBX|1053|CWE|81304-8^Variant Analysis Method [Type]^LN|2d|LA26398-0^Sequencing^LN|
+OBX|1054|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
+OBX|1055|CWE|69548-6^Genetic Variant Assessment^LN|2d|LA9633-4^Present^LN|
+OBX|1056|CWE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
+OBX|1057|CWE|83005-9^Variant Category^LN|2e|LA26801-3^Simple^LN|
+OBX|1058|ST|47998-0^Variant Display Name^LN|2e|NC_000001.10:399:A:G|
+OBX|1059|CWE|48018-6^Gene Studied^UFMOLLRR|2e|HGNC:0000^NoGene^HGNC|
+OBX|1060|CWE|48004-6^DNA Change c.HGVS^LN|2e|NC_000001.10:399:A:G|
+OBX|1061|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2e|NC_000001.10|
+OBX|1062|ST|69547-8^Genomic ref allele^LN|2e|A|
+OBX|1063|NR|81254-5^Genomic allele start-end^LN|2e|400|
+OBX|1064|ST|69551-0^Genomic alt allele^LN|2e|G|
+OBX|1065|ST|48000-4^Chromosome^LN|2e|1|
+OBX|1066|CWE|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
+OBX|1067|CWE|81304-8^Variant Analysis Method [Type]^LN|2e|LA26398-0^Sequencing^LN|
+OBX|1068|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
+OBX|1069|CWE|69548-6^Genetic Variant Assessment^LN|2e|LA9633-4^Present^LN|
+OBX|1070|CWE|53034-5^Allelic state^LN|2e|LA6705-3^Homozygous^LN|
+OBX|1071|CWE|83005-9^Variant Category^LN|2f|LA26801-3^Simple^LN|
+OBX|1072|ST|47998-0^Variant Display Name^LN|2f|NC_000001.10:499:A:G|
+OBX|1073|CWE|48018-6^Gene Studied^UFMOLLRR|2f|HGNC:0000^NoGene^HGNC|
+OBX|1074|CWE|48004-6^DNA Change c.HGVS^LN|2f|NC_000001.10:499:A:G|
+OBX|1075|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2f|NC_000001.10|
+OBX|1076|ST|69547-8^Genomic ref allele^LN|2f|A|
+OBX|1077|NR|81254-5^Genomic allele start-end^LN|2f|500|
+OBX|1078|ST|69551-0^Genomic alt allele^LN|2f|G|
+OBX|1079|ST|48000-4^Chromosome^LN|2f|1|
+OBX|1080|CWE|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
+OBX|1081|CWE|81304-8^Variant Analysis Method [Type]^LN|2f|LA26398-0^Sequencing^LN|
+OBX|1082|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
+OBX|1083|CWE|69548-6^Genetic Variant Assessment^LN|2f|LA9633-4^Present^LN|
+OBX|1084|CWE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|
+OBX|1085|CWE|83005-9^Variant Category^LN|2g|LA26801-3^Simple^LN|
+OBX|1086|ST|47998-0^Variant Display Name^LN|2g|NC_000001.10:599:A:G|
+OBX|1087|CWE|48018-6^Gene Studied^UFMOLLRR|2g|HGNC:0000^NoGene^HGNC|
+OBX|1088|CWE|48004-6^DNA Change c.HGVS^LN|2g|NC_000001.10:599:A:G|
+OBX|1089|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2g|NC_000001.10|
+OBX|1090|ST|69547-8^Genomic ref allele^LN|2g|A|
+OBX|1091|NR|81254-5^Genomic allele start-end^LN|2g|600|
+OBX|1092|ST|69551-0^Genomic alt allele^LN|2g|G|
+OBX|1093|ST|48000-4^Chromosome^LN|2g|1|
+OBX|1094|CWE|48002-0^Genomic Source Class [Type]^LN|2g|LA6683-2^Germline^LN|
+OBX|1095|CWE|81304-8^Variant Analysis Method [Type]^LN|2g|LA26398-0^Sequencing^LN|
+OBX|1096|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2g|not specified|
+OBX|1097|CWE|69548-6^Genetic Variant Assessment^LN|2g|LA9633-4^Present^LN|
+OBX|1098|CWE|53034-5^Allelic state^LN|2g|LA6706-1^Heterozygous^LN|
+OBX|1099|CWE|83005-9^Variant Category^LN|2h|LA26801-3^Simple^LN|
+OBX|1100|ST|47998-0^Variant Display Name^LN|2h|NC_000001.10:699:A:G|
+OBX|1101|CWE|48018-6^Gene Studied^UFMOLLRR|2h|HGNC:0000^NoGene^HGNC|
+OBX|1102|CWE|48004-6^DNA Change c.HGVS^LN|2h|NC_000001.10:699:A:G|
+OBX|1103|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2h|NC_000001.10|
+OBX|1104|ST|69547-8^Genomic ref allele^LN|2h|A|
+OBX|1105|NR|81254-5^Genomic allele start-end^LN|2h|700|
+OBX|1106|ST|69551-0^Genomic alt allele^LN|2h|G|
+OBX|1107|ST|48000-4^Chromosome^LN|2h|1|
+OBX|1108|CWE|48002-0^Genomic Source Class [Type]^LN|2h|LA6683-2^Germline^LN|
+OBX|1109|CWE|81304-8^Variant Analysis Method [Type]^LN|2h|LA26398-0^Sequencing^LN|
+OBX|1110|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2h|not specified|
+OBX|1111|CWE|69548-6^Genetic Variant Assessment^LN|2h|LA9633-4^Present^LN|
+OBX|1112|CWE|53034-5^Allelic state^LN|2h|LA6706-1^Heterozygous^LN|

--- a/vcf2hl7v2/test/expected_example1_wo_patient.txt
+++ b/vcf2hl7v2/test/expected_example1_wo_patient.txt
@@ -1,97 +1,113 @@
-OBX|1000|TX|51968-6^Discrete variation analysis overall interpretation^LN|1|Positive|
-OBX|1001|ST|83005-9^Variant Category^LN|2a|Simple|
+OBX|1000|TX|51968-6^Genetic Analysis Overall Interpretation^UFMOLLRR|1|Positive|
+OBX|1001|CWE|83005-9^Variant Category^LN|2a|LA26801-3^Simple^LN|
 OBX|1002|ST|47998-0^Variant Display Name^LN|2a|NC_000001.10:14:.:G|
-OBX|1003|CWE|48018-6^Gene Studied^LN|2a|HGNC:0000^NoGene^HGNC|
-OBX|1004|ST|48004-6^DNA Change c.HGVS^LN|2a|NC_000001.10:14:.:G|
-OBX|1005|ST|48013-7^Genomic reference sequence^LN|2a|NC_000001.10|
+OBX|1003|CWE|48018-6^Gene Studied^UFMOLLRR|2a|HGNC:0000^NoGene^HGNC|
+OBX|1004|CWE|48004-6^DNA Change c.HGVS^LN|2a|NC_000001.10:14:.:G|
+OBX|1005|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2a|NC_000001.10|
 OBX|1006|ST|69547-8^Genomic ref allele^LN|2a|.|
 OBX|1007|NR|81254-5^Genomic allele start-end^LN|2a|15|
 OBX|1008|ST|69551-0^Genomic alt allele^LN|2a|G|
-OBX|1009|ST|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
-OBX|1010|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
-OBX|1011|ST|69548-6^Genetic Variant Assessment^LN|2a|Present|
-OBX|1012|CNE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
-OBX|1013|ST|83005-9^Variant Category^LN|2b|Simple|
-OBX|1014|ST|47998-0^Variant Display Name^LN|2b|NC_000001.10:15:A,T:G|
-OBX|1015|CWE|48018-6^Gene Studied^LN|2b|HGNC:0000^NoGene^HGNC|
-OBX|1016|ST|48004-6^DNA Change c.HGVS^LN|2b|NC_000001.10:15:A,T:G|
-OBX|1017|ST|48013-7^Genomic reference sequence^LN|2b|NC_000001.10|
-OBX|1018|ST|69547-8^Genomic ref allele^LN|2b|A,T|
-OBX|1019|NR|81254-5^Genomic allele start-end^LN|2b|16|
-OBX|1020|ST|69551-0^Genomic alt allele^LN|2b|G|
-OBX|1021|ST|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
-OBX|1022|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
-OBX|1023|ST|69548-6^Genetic Variant Assessment^LN|2b|Present|
-OBX|1024|CNE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
-OBX|1025|ST|83005-9^Variant Category^LN|2c|Simple|
-OBX|1026|ST|47998-0^Variant Display Name^LN|2c|NC_000001.10:19::G|
-OBX|1027|CWE|48018-6^Gene Studied^LN|2c|HGNC:0000^NoGene^HGNC|
-OBX|1028|ST|48004-6^DNA Change c.HGVS^LN|2c|NC_000001.10:19::G|
-OBX|1029|ST|48013-7^Genomic reference sequence^LN|2c|NC_000001.10|
-OBX|1030|ST|69547-8^Genomic ref allele^LN|2c||
-OBX|1031|NR|81254-5^Genomic allele start-end^LN|2c|20|
-OBX|1032|ST|69551-0^Genomic alt allele^LN|2c|G|
-OBX|1033|ST|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
-OBX|1034|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
-OBX|1035|ST|69548-6^Genetic Variant Assessment^LN|2c|Present|
-OBX|1036|CNE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
-OBX|1037|ST|83005-9^Variant Category^LN|2d|Simple|
-OBX|1038|ST|47998-0^Variant Display Name^LN|2d|NC_000001.10:300:A:G|
-OBX|1039|CWE|48018-6^Gene Studied^LN|2d|HGNC:0000^NoGene^HGNC|
-OBX|1040|ST|48004-6^DNA Change c.HGVS^LN|2d|NC_000001.10:300:A:G|
-OBX|1041|ST|48013-7^Genomic reference sequence^LN|2d|NC_000001.10|
-OBX|1042|ST|69547-8^Genomic ref allele^LN|2d|A|
-OBX|1043|NR|81254-5^Genomic allele start-end^LN|2d|301|
-OBX|1044|ST|69551-0^Genomic alt allele^LN|2d|G|
-OBX|1045|ST|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
-OBX|1046|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
-OBX|1047|ST|69548-6^Genetic Variant Assessment^LN|2d|Present|
-OBX|1048|CNE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
-OBX|1049|ST|83005-9^Variant Category^LN|2e|Simple|
-OBX|1050|ST|47998-0^Variant Display Name^LN|2e|NC_000001.10:399:A:G|
-OBX|1051|CWE|48018-6^Gene Studied^LN|2e|HGNC:0000^NoGene^HGNC|
-OBX|1052|ST|48004-6^DNA Change c.HGVS^LN|2e|NC_000001.10:399:A:G|
-OBX|1053|ST|48013-7^Genomic reference sequence^LN|2e|NC_000001.10|
-OBX|1054|ST|69547-8^Genomic ref allele^LN|2e|A|
-OBX|1055|NR|81254-5^Genomic allele start-end^LN|2e|400|
-OBX|1056|ST|69551-0^Genomic alt allele^LN|2e|G|
-OBX|1057|ST|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
-OBX|1058|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
-OBX|1059|ST|69548-6^Genetic Variant Assessment^LN|2e|Present|
-OBX|1060|CNE|53034-5^Allelic state^LN|2e|LA6705-3^Homozygous^LN|
-OBX|1061|ST|83005-9^Variant Category^LN|2f|Simple|
-OBX|1062|ST|47998-0^Variant Display Name^LN|2f|NC_000001.10:499:A:G|
-OBX|1063|CWE|48018-6^Gene Studied^LN|2f|HGNC:0000^NoGene^HGNC|
-OBX|1064|ST|48004-6^DNA Change c.HGVS^LN|2f|NC_000001.10:499:A:G|
-OBX|1065|ST|48013-7^Genomic reference sequence^LN|2f|NC_000001.10|
-OBX|1066|ST|69547-8^Genomic ref allele^LN|2f|A|
-OBX|1067|NR|81254-5^Genomic allele start-end^LN|2f|500|
-OBX|1068|ST|69551-0^Genomic alt allele^LN|2f|G|
-OBX|1069|ST|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
-OBX|1070|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
-OBX|1071|ST|69548-6^Genetic Variant Assessment^LN|2f|Present|
-OBX|1072|CNE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|
-OBX|1073|ST|83005-9^Variant Category^LN|2g|Simple|
-OBX|1074|ST|47998-0^Variant Display Name^LN|2g|NC_000001.10:599:A:G|
-OBX|1075|CWE|48018-6^Gene Studied^LN|2g|HGNC:0000^NoGene^HGNC|
-OBX|1076|ST|48004-6^DNA Change c.HGVS^LN|2g|NC_000001.10:599:A:G|
-OBX|1077|ST|48013-7^Genomic reference sequence^LN|2g|NC_000001.10|
-OBX|1078|ST|69547-8^Genomic ref allele^LN|2g|A|
-OBX|1079|NR|81254-5^Genomic allele start-end^LN|2g|600|
-OBX|1080|ST|69551-0^Genomic alt allele^LN|2g|G|
-OBX|1081|ST|48002-0^Genomic Source Class [Type]^LN|2g|LA6683-2^Germline^LN|
-OBX|1082|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2g|not specified|
-OBX|1083|ST|69548-6^Genetic Variant Assessment^LN|2g|Present|
-OBX|1084|CNE|53034-5^Allelic state^LN|2g|LA6706-1^Heterozygous^LN|
-OBX|1085|ST|83005-9^Variant Category^LN|2h|Simple|
-OBX|1086|ST|47998-0^Variant Display Name^LN|2h|NC_000001.10:699:A:G|
-OBX|1087|CWE|48018-6^Gene Studied^LN|2h|HGNC:0000^NoGene^HGNC|
-OBX|1088|ST|48004-6^DNA Change c.HGVS^LN|2h|NC_000001.10:699:A:G|
-OBX|1089|ST|48013-7^Genomic reference sequence^LN|2h|NC_000001.10|
-OBX|1090|ST|69547-8^Genomic ref allele^LN|2h|A|
-OBX|1091|NR|81254-5^Genomic allele start-end^LN|2h|700|
-OBX|1092|ST|69551-0^Genomic alt allele^LN|2h|G|
-OBX|1093|ST|48002-0^Genomic Source Class [Type]^LN|2h|LA6683-2^Germline^LN|
-OBX|1094|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2h|not specified|
-OBX|1095|ST|69548-6^Genetic Variant Assessment^LN|2h|Present|
-OBX|1096|CNE|53034-5^Allelic state^LN|2h|LA6706-1^Heterozygous^LN|
+OBX|1009|ST|48000-4^Chromosome^LN|2a|1|
+OBX|1010|CWE|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
+OBX|1011|CWE|81304-8^Variant Analysis Method [Type]^LN|2a|LA26398-0^Sequencing^LN|
+OBX|1012|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
+OBX|1013|CWE|69548-6^Genetic Variant Assessment^LN|2a|LA9633-4^Present^LN|
+OBX|1014|CWE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
+OBX|1015|CWE|83005-9^Variant Category^LN|2b|LA26801-3^Simple^LN|
+OBX|1016|ST|47998-0^Variant Display Name^LN|2b|NC_000001.10:15:A,T:G|
+OBX|1017|CWE|48018-6^Gene Studied^UFMOLLRR|2b|HGNC:0000^NoGene^HGNC|
+OBX|1018|CWE|48004-6^DNA Change c.HGVS^LN|2b|NC_000001.10:15:A,T:G|
+OBX|1019|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2b|NC_000001.10|
+OBX|1020|ST|69547-8^Genomic ref allele^LN|2b|A,T|
+OBX|1021|NR|81254-5^Genomic allele start-end^LN|2b|16|
+OBX|1022|ST|69551-0^Genomic alt allele^LN|2b|G|
+OBX|1023|ST|48000-4^Chromosome^LN|2b|1|
+OBX|1024|CWE|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
+OBX|1025|CWE|81304-8^Variant Analysis Method [Type]^LN|2b|LA26398-0^Sequencing^LN|
+OBX|1026|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
+OBX|1027|CWE|69548-6^Genetic Variant Assessment^LN|2b|LA9633-4^Present^LN|
+OBX|1028|CWE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
+OBX|1029|CWE|83005-9^Variant Category^LN|2c|LA26801-3^Simple^LN|
+OBX|1030|ST|47998-0^Variant Display Name^LN|2c|NC_000001.10:19::G|
+OBX|1031|CWE|48018-6^Gene Studied^UFMOLLRR|2c|HGNC:0000^NoGene^HGNC|
+OBX|1032|CWE|48004-6^DNA Change c.HGVS^LN|2c|NC_000001.10:19::G|
+OBX|1033|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2c|NC_000001.10|
+OBX|1034|ST|69547-8^Genomic ref allele^LN|2c||
+OBX|1035|NR|81254-5^Genomic allele start-end^LN|2c|20|
+OBX|1036|ST|69551-0^Genomic alt allele^LN|2c|G|
+OBX|1037|ST|48000-4^Chromosome^LN|2c|1|
+OBX|1038|CWE|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
+OBX|1039|CWE|81304-8^Variant Analysis Method [Type]^LN|2c|LA26398-0^Sequencing^LN|
+OBX|1040|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
+OBX|1041|CWE|69548-6^Genetic Variant Assessment^LN|2c|LA9633-4^Present^LN|
+OBX|1042|CWE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
+OBX|1043|CWE|83005-9^Variant Category^LN|2d|LA26801-3^Simple^LN|
+OBX|1044|ST|47998-0^Variant Display Name^LN|2d|NC_000001.10:300:A:G|
+OBX|1045|CWE|48018-6^Gene Studied^UFMOLLRR|2d|HGNC:0000^NoGene^HGNC|
+OBX|1046|CWE|48004-6^DNA Change c.HGVS^LN|2d|NC_000001.10:300:A:G|
+OBX|1047|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2d|NC_000001.10|
+OBX|1048|ST|69547-8^Genomic ref allele^LN|2d|A|
+OBX|1049|NR|81254-5^Genomic allele start-end^LN|2d|301|
+OBX|1050|ST|69551-0^Genomic alt allele^LN|2d|G|
+OBX|1051|ST|48000-4^Chromosome^LN|2d|1|
+OBX|1052|CWE|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
+OBX|1053|CWE|81304-8^Variant Analysis Method [Type]^LN|2d|LA26398-0^Sequencing^LN|
+OBX|1054|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
+OBX|1055|CWE|69548-6^Genetic Variant Assessment^LN|2d|LA9633-4^Present^LN|
+OBX|1056|CWE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
+OBX|1057|CWE|83005-9^Variant Category^LN|2e|LA26801-3^Simple^LN|
+OBX|1058|ST|47998-0^Variant Display Name^LN|2e|NC_000001.10:399:A:G|
+OBX|1059|CWE|48018-6^Gene Studied^UFMOLLRR|2e|HGNC:0000^NoGene^HGNC|
+OBX|1060|CWE|48004-6^DNA Change c.HGVS^LN|2e|NC_000001.10:399:A:G|
+OBX|1061|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2e|NC_000001.10|
+OBX|1062|ST|69547-8^Genomic ref allele^LN|2e|A|
+OBX|1063|NR|81254-5^Genomic allele start-end^LN|2e|400|
+OBX|1064|ST|69551-0^Genomic alt allele^LN|2e|G|
+OBX|1065|ST|48000-4^Chromosome^LN|2e|1|
+OBX|1066|CWE|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
+OBX|1067|CWE|81304-8^Variant Analysis Method [Type]^LN|2e|LA26398-0^Sequencing^LN|
+OBX|1068|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
+OBX|1069|CWE|69548-6^Genetic Variant Assessment^LN|2e|LA9633-4^Present^LN|
+OBX|1070|CWE|53034-5^Allelic state^LN|2e|LA6705-3^Homozygous^LN|
+OBX|1071|CWE|83005-9^Variant Category^LN|2f|LA26801-3^Simple^LN|
+OBX|1072|ST|47998-0^Variant Display Name^LN|2f|NC_000001.10:499:A:G|
+OBX|1073|CWE|48018-6^Gene Studied^UFMOLLRR|2f|HGNC:0000^NoGene^HGNC|
+OBX|1074|CWE|48004-6^DNA Change c.HGVS^LN|2f|NC_000001.10:499:A:G|
+OBX|1075|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2f|NC_000001.10|
+OBX|1076|ST|69547-8^Genomic ref allele^LN|2f|A|
+OBX|1077|NR|81254-5^Genomic allele start-end^LN|2f|500|
+OBX|1078|ST|69551-0^Genomic alt allele^LN|2f|G|
+OBX|1079|ST|48000-4^Chromosome^LN|2f|1|
+OBX|1080|CWE|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
+OBX|1081|CWE|81304-8^Variant Analysis Method [Type]^LN|2f|LA26398-0^Sequencing^LN|
+OBX|1082|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
+OBX|1083|CWE|69548-6^Genetic Variant Assessment^LN|2f|LA9633-4^Present^LN|
+OBX|1084|CWE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|
+OBX|1085|CWE|83005-9^Variant Category^LN|2g|LA26801-3^Simple^LN|
+OBX|1086|ST|47998-0^Variant Display Name^LN|2g|NC_000001.10:599:A:G|
+OBX|1087|CWE|48018-6^Gene Studied^UFMOLLRR|2g|HGNC:0000^NoGene^HGNC|
+OBX|1088|CWE|48004-6^DNA Change c.HGVS^LN|2g|NC_000001.10:599:A:G|
+OBX|1089|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2g|NC_000001.10|
+OBX|1090|ST|69547-8^Genomic ref allele^LN|2g|A|
+OBX|1091|NR|81254-5^Genomic allele start-end^LN|2g|600|
+OBX|1092|ST|69551-0^Genomic alt allele^LN|2g|G|
+OBX|1093|ST|48000-4^Chromosome^LN|2g|1|
+OBX|1094|CWE|48002-0^Genomic Source Class [Type]^LN|2g|LA6683-2^Germline^LN|
+OBX|1095|CWE|81304-8^Variant Analysis Method [Type]^LN|2g|LA26398-0^Sequencing^LN|
+OBX|1096|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2g|not specified|
+OBX|1097|CWE|69548-6^Genetic Variant Assessment^LN|2g|LA9633-4^Present^LN|
+OBX|1098|CWE|53034-5^Allelic state^LN|2g|LA6706-1^Heterozygous^LN|
+OBX|1099|CWE|83005-9^Variant Category^LN|2h|LA26801-3^Simple^LN|
+OBX|1100|ST|47998-0^Variant Display Name^LN|2h|NC_000001.10:699:A:G|
+OBX|1101|CWE|48018-6^Gene Studied^UFMOLLRR|2h|HGNC:0000^NoGene^HGNC|
+OBX|1102|CWE|48004-6^DNA Change c.HGVS^LN|2h|NC_000001.10:699:A:G|
+OBX|1103|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2h|NC_000001.10|
+OBX|1104|ST|69547-8^Genomic ref allele^LN|2h|A|
+OBX|1105|NR|81254-5^Genomic allele start-end^LN|2h|700|
+OBX|1106|ST|69551-0^Genomic alt allele^LN|2h|G|
+OBX|1107|ST|48000-4^Chromosome^LN|2h|1|
+OBX|1108|CWE|48002-0^Genomic Source Class [Type]^LN|2h|LA6683-2^Germline^LN|
+OBX|1109|CWE|81304-8^Variant Analysis Method [Type]^LN|2h|LA26398-0^Sequencing^LN|
+OBX|1110|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2h|not specified|
+OBX|1111|CWE|69548-6^Genetic Variant Assessment^LN|2h|LA9633-4^Present^LN|
+OBX|1112|CWE|53034-5^Allelic state^LN|2h|LA6706-1^Heterozygous^LN|

--- a/vcf2hl7v2/test/expected_example3.txt
+++ b/vcf2hl7v2/test/expected_example3.txt
@@ -3,65 +3,75 @@ OBX|1001|NR|51959-5^Range(s) of DNA sequence examined^LN|1a.a|50000^52000|
 OBX|1002|NR|51959-5^Range(s) of DNA sequence examined^LN|1a.b|55000^60600|
 OBX|1003|ST|48013-7^Genomic reference sequence^LN|1b|NC_012920.1|
 OBX|1004|NR|51959-5^Range(s) of DNA sequence examined^LN|1b.a|50000^60025|
-OBX|1005|TX|51968-6^Discrete variation analysis overall interpretation^LN|1|Positive|
-OBX|1006|ST|83005-9^Variant Category^LN|2a|Simple|
+OBX|1005|TX|51968-6^Genetic Analysis Overall Interpretation^UFMOLLRR|1|Positive|
+OBX|1006|CWE|83005-9^Variant Category^LN|2a|LA26801-3^Simple^LN|
 OBX|1007|ST|47998-0^Variant Display Name^LN|2a|NC_000023.11:60465:T:C|
-OBX|1008|CWE|48018-6^Gene Studied^LN|2a|HGNC:0000^NoGene^HGNC|
-OBX|1009|ST|48004-6^DNA Change c.HGVS^LN|2a|NC_000023.11:60465:T:C|
-OBX|1010|ST|48013-7^Genomic reference sequence^LN|2a|NC_000023.11|
+OBX|1008|CWE|48018-6^Gene Studied^UFMOLLRR|2a|HGNC:0000^NoGene^HGNC|
+OBX|1009|CWE|48004-6^DNA Change c.HGVS^LN|2a|NC_000023.11:60465:T:C|
+OBX|1010|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2a|NC_000023.11|
 OBX|1011|ST|69547-8^Genomic ref allele^LN|2a|T|
 OBX|1012|NR|81254-5^Genomic allele start-end^LN|2a|60466|
 OBX|1013|ST|69551-0^Genomic alt allele^LN|2a|C|
-OBX|1014|ST|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
-OBX|1015|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
-OBX|1016|ST|69548-6^Genetic Variant Assessment^LN|2a|Present|
-OBX|1017|CNE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
-OBX|1018|ST|83005-9^Variant Category^LN|2b|Simple|
-OBX|1019|ST|47998-0^Variant Display Name^LN|2b|NC_000023.11:60578:G:A|
-OBX|1020|CWE|48018-6^Gene Studied^LN|2b|HGNC:0000^NoGene^HGNC|
-OBX|1021|ST|48004-6^DNA Change c.HGVS^LN|2b|NC_000023.11:60578:G:A|
-OBX|1022|ST|48013-7^Genomic reference sequence^LN|2b|NC_000023.11|
-OBX|1023|ST|69547-8^Genomic ref allele^LN|2b|G|
-OBX|1024|NR|81254-5^Genomic allele start-end^LN|2b|60579|
-OBX|1025|ST|69551-0^Genomic alt allele^LN|2b|A|
-OBX|1026|ST|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
-OBX|1027|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
-OBX|1028|ST|69548-6^Genetic Variant Assessment^LN|2b|Present|
-OBX|1029|CNE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
-OBX|1030|ST|83005-9^Variant Category^LN|2c|Simple|
-OBX|1031|ST|47998-0^Variant Display Name^LN|2c|NC_000023.11:60582:G:C|
-OBX|1032|CWE|48018-6^Gene Studied^LN|2c|HGNC:0000^NoGene^HGNC|
-OBX|1033|ST|48004-6^DNA Change c.HGVS^LN|2c|NC_000023.11:60582:G:C|
-OBX|1034|ST|48013-7^Genomic reference sequence^LN|2c|NC_000023.11|
-OBX|1035|ST|69547-8^Genomic ref allele^LN|2c|G|
-OBX|1036|NR|81254-5^Genomic allele start-end^LN|2c|60583|
-OBX|1037|ST|69551-0^Genomic alt allele^LN|2c|C|
-OBX|1038|ST|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
-OBX|1039|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
-OBX|1040|ST|69548-6^Genetic Variant Assessment^LN|2c|Present|
-OBX|1041|CNE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
-OBX|1042|ST|83005-9^Variant Category^LN|2d|Simple|
-OBX|1043|ST|47998-0^Variant Display Name^LN|2d|NC_000023.11:60592:A:T|
-OBX|1044|CWE|48018-6^Gene Studied^LN|2d|HGNC:0000^NoGene^HGNC|
-OBX|1045|ST|48004-6^DNA Change c.HGVS^LN|2d|NC_000023.11:60592:A:T|
-OBX|1046|ST|48013-7^Genomic reference sequence^LN|2d|NC_000023.11|
-OBX|1047|ST|69547-8^Genomic ref allele^LN|2d|A|
-OBX|1048|NR|81254-5^Genomic allele start-end^LN|2d|60593|
-OBX|1049|ST|69551-0^Genomic alt allele^LN|2d|T|
-OBX|1050|ST|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
-OBX|1051|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
-OBX|1052|ST|69548-6^Genetic Variant Assessment^LN|2d|Present|
-OBX|1053|CNE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
-OBX|1054|ST|83005-9^Variant Category^LN|2e|Simple|
-OBX|1055|ST|47998-0^Variant Display Name^LN|2e|NC_012920.1:60017:A:C|
-OBX|1056|CWE|48018-6^Gene Studied^LN|2e|HGNC:0000^NoGene^HGNC|
-OBX|1057|ST|48004-6^DNA Change c.HGVS^LN|2e|NC_012920.1:60017:A:C|
-OBX|1058|ST|48013-7^Genomic reference sequence^LN|2e|NC_012920.1|
-OBX|1059|ST|69547-8^Genomic ref allele^LN|2e|A|
-OBX|1060|NR|81254-5^Genomic allele start-end^LN|2e|60018|
-OBX|1061|ST|69551-0^Genomic alt allele^LN|2e|C|
-OBX|1062|ST|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
-OBX|1063|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
-OBX|1064|ST|69548-6^Genetic Variant Assessment^LN|2e|Present|
-OBX|1065|CNE|81258-6^Allelic frequency^LN|2e|0.8|
-OBX|1066|CNE|53034-5^Allelic state^LN|2e|LA6703-8^Heteroplasmic^LN|
+OBX|1014|ST|48000-4^Chromosome^LN|2a|X|
+OBX|1015|CWE|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
+OBX|1016|CWE|81304-8^Variant Analysis Method [Type]^LN|2a|LA26398-0^Sequencing^LN|
+OBX|1017|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
+OBX|1018|CWE|69548-6^Genetic Variant Assessment^LN|2a|LA9633-4^Present^LN|
+OBX|1019|CWE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
+OBX|1020|CWE|83005-9^Variant Category^LN|2b|LA26801-3^Simple^LN|
+OBX|1021|ST|47998-0^Variant Display Name^LN|2b|NC_000023.11:60578:G:A|
+OBX|1022|CWE|48018-6^Gene Studied^UFMOLLRR|2b|HGNC:0000^NoGene^HGNC|
+OBX|1023|CWE|48004-6^DNA Change c.HGVS^LN|2b|NC_000023.11:60578:G:A|
+OBX|1024|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2b|NC_000023.11|
+OBX|1025|ST|69547-8^Genomic ref allele^LN|2b|G|
+OBX|1026|NR|81254-5^Genomic allele start-end^LN|2b|60579|
+OBX|1027|ST|69551-0^Genomic alt allele^LN|2b|A|
+OBX|1028|ST|48000-4^Chromosome^LN|2b|X|
+OBX|1029|CWE|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
+OBX|1030|CWE|81304-8^Variant Analysis Method [Type]^LN|2b|LA26398-0^Sequencing^LN|
+OBX|1031|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
+OBX|1032|CWE|69548-6^Genetic Variant Assessment^LN|2b|LA9633-4^Present^LN|
+OBX|1033|CWE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
+OBX|1034|CWE|83005-9^Variant Category^LN|2c|LA26801-3^Simple^LN|
+OBX|1035|ST|47998-0^Variant Display Name^LN|2c|NC_000023.11:60582:G:C|
+OBX|1036|CWE|48018-6^Gene Studied^UFMOLLRR|2c|HGNC:0000^NoGene^HGNC|
+OBX|1037|CWE|48004-6^DNA Change c.HGVS^LN|2c|NC_000023.11:60582:G:C|
+OBX|1038|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2c|NC_000023.11|
+OBX|1039|ST|69547-8^Genomic ref allele^LN|2c|G|
+OBX|1040|NR|81254-5^Genomic allele start-end^LN|2c|60583|
+OBX|1041|ST|69551-0^Genomic alt allele^LN|2c|C|
+OBX|1042|ST|48000-4^Chromosome^LN|2c|X|
+OBX|1043|CWE|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
+OBX|1044|CWE|81304-8^Variant Analysis Method [Type]^LN|2c|LA26398-0^Sequencing^LN|
+OBX|1045|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
+OBX|1046|CWE|69548-6^Genetic Variant Assessment^LN|2c|LA9633-4^Present^LN|
+OBX|1047|CWE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
+OBX|1048|CWE|83005-9^Variant Category^LN|2d|LA26801-3^Simple^LN|
+OBX|1049|ST|47998-0^Variant Display Name^LN|2d|NC_000023.11:60592:A:T|
+OBX|1050|CWE|48018-6^Gene Studied^UFMOLLRR|2d|HGNC:0000^NoGene^HGNC|
+OBX|1051|CWE|48004-6^DNA Change c.HGVS^LN|2d|NC_000023.11:60592:A:T|
+OBX|1052|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2d|NC_000023.11|
+OBX|1053|ST|69547-8^Genomic ref allele^LN|2d|A|
+OBX|1054|NR|81254-5^Genomic allele start-end^LN|2d|60593|
+OBX|1055|ST|69551-0^Genomic alt allele^LN|2d|T|
+OBX|1056|ST|48000-4^Chromosome^LN|2d|X|
+OBX|1057|CWE|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
+OBX|1058|CWE|81304-8^Variant Analysis Method [Type]^LN|2d|LA26398-0^Sequencing^LN|
+OBX|1059|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
+OBX|1060|CWE|69548-6^Genetic Variant Assessment^LN|2d|LA9633-4^Present^LN|
+OBX|1061|CWE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
+OBX|1062|CWE|83005-9^Variant Category^LN|2e|LA26801-3^Simple^LN|
+OBX|1063|ST|47998-0^Variant Display Name^LN|2e|NC_012920.1:60017:A:C|
+OBX|1064|CWE|48018-6^Gene Studied^UFMOLLRR|2e|HGNC:0000^NoGene^HGNC|
+OBX|1065|CWE|48004-6^DNA Change c.HGVS^LN|2e|NC_012920.1:60017:A:C|
+OBX|1066|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2e|NC_012920.1|
+OBX|1067|ST|69547-8^Genomic ref allele^LN|2e|A|
+OBX|1068|NR|81254-5^Genomic allele start-end^LN|2e|60018|
+OBX|1069|ST|69551-0^Genomic alt allele^LN|2e|C|
+OBX|1070|ST|48000-4^Chromosome^LN|2e|M|
+OBX|1071|CWE|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
+OBX|1072|CWE|81304-8^Variant Analysis Method [Type]^LN|2e|LA26398-0^Sequencing^LN|
+OBX|1073|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
+OBX|1074|CWE|69548-6^Genetic Variant Assessment^LN|2e|LA9633-4^Present^LN|
+OBX|1075|CWE|53034-5^Allelic state^LN|2e|LA6703-8^Heteroplasmic^LN|
+OBX|1076|NM|81258-6^Allelic frequency^LN|2e|0.8|

--- a/vcf2hl7v2/test/expected_example4.txt
+++ b/vcf2hl7v2/test/expected_example4.txt
@@ -48,76 +48,88 @@ OBX|1046|ST|48013-7^Genomic reference sequence^LN|1x|NC_000024.10|
 OBX|1047|NR|51959-5^Range(s) of DNA sequence examined^LN|1x.a|1^59373566|
 OBX|1048|ST|48013-7^Genomic reference sequence^LN|1y|NC_012920.1|
 OBX|1049|NR|51959-5^Range(s) of DNA sequence examined^LN|1y.a|1^16569|
-OBX|1050|TX|51968-6^Discrete variation analysis overall interpretation^LN|1|Positive|
-OBX|1051|ST|83005-9^Variant Category^LN|2a|Simple|
+OBX|1050|TX|51968-6^Genetic Analysis Overall Interpretation^UFMOLLRR|1|Positive|
+OBX|1051|CWE|83005-9^Variant Category^LN|2a|LA26801-3^Simple^LN|
 OBX|1052|ST|47998-0^Variant Display Name^LN|2a|NC_000023.11:60465:T:C|
-OBX|1053|CWE|48018-6^Gene Studied^LN|2a|HGNC:0000^NoGene^HGNC|
-OBX|1054|ST|48004-6^DNA Change c.HGVS^LN|2a|NC_000023.11:60465:T:C|
-OBX|1055|ST|48013-7^Genomic reference sequence^LN|2a|NC_000023.11|
+OBX|1053|CWE|48018-6^Gene Studied^UFMOLLRR|2a|HGNC:0000^NoGene^HGNC|
+OBX|1054|CWE|48004-6^DNA Change c.HGVS^LN|2a|NC_000023.11:60465:T:C|
+OBX|1055|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2a|NC_000023.11|
 OBX|1056|ST|69547-8^Genomic ref allele^LN|2a|T|
 OBX|1057|NR|81254-5^Genomic allele start-end^LN|2a|60466|
 OBX|1058|ST|69551-0^Genomic alt allele^LN|2a|C|
-OBX|1059|ST|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
-OBX|1060|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
-OBX|1061|ST|69548-6^Genetic Variant Assessment^LN|2a|Present|
-OBX|1062|CNE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
-OBX|1063|ST|83005-9^Variant Category^LN|2b|Simple|
-OBX|1064|ST|47998-0^Variant Display Name^LN|2b|NC_000023.11:60578:G:A|
-OBX|1065|CWE|48018-6^Gene Studied^LN|2b|HGNC:0000^NoGene^HGNC|
-OBX|1066|ST|48004-6^DNA Change c.HGVS^LN|2b|NC_000023.11:60578:G:A|
-OBX|1067|ST|48013-7^Genomic reference sequence^LN|2b|NC_000023.11|
-OBX|1068|ST|69547-8^Genomic ref allele^LN|2b|G|
-OBX|1069|NR|81254-5^Genomic allele start-end^LN|2b|60579|
-OBX|1070|ST|69551-0^Genomic alt allele^LN|2b|A|
-OBX|1071|ST|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
-OBX|1072|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
-OBX|1073|ST|69548-6^Genetic Variant Assessment^LN|2b|Present|
-OBX|1074|CNE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
-OBX|1075|ST|83005-9^Variant Category^LN|2c|Simple|
-OBX|1076|ST|47998-0^Variant Display Name^LN|2c|NC_000023.11:60582:G:C|
-OBX|1077|CWE|48018-6^Gene Studied^LN|2c|HGNC:0000^NoGene^HGNC|
-OBX|1078|ST|48004-6^DNA Change c.HGVS^LN|2c|NC_000023.11:60582:G:C|
-OBX|1079|ST|48013-7^Genomic reference sequence^LN|2c|NC_000023.11|
-OBX|1080|ST|69547-8^Genomic ref allele^LN|2c|G|
-OBX|1081|NR|81254-5^Genomic allele start-end^LN|2c|60583|
-OBX|1082|ST|69551-0^Genomic alt allele^LN|2c|C|
-OBX|1083|ST|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
-OBX|1084|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
-OBX|1085|ST|69548-6^Genetic Variant Assessment^LN|2c|Present|
-OBX|1086|CNE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
-OBX|1087|ST|83005-9^Variant Category^LN|2d|Simple|
-OBX|1088|ST|47998-0^Variant Display Name^LN|2d|NC_000023.11:60592:A:T|
-OBX|1089|CWE|48018-6^Gene Studied^LN|2d|HGNC:0000^NoGene^HGNC|
-OBX|1090|ST|48004-6^DNA Change c.HGVS^LN|2d|NC_000023.11:60592:A:T|
-OBX|1091|ST|48013-7^Genomic reference sequence^LN|2d|NC_000023.11|
-OBX|1092|ST|69547-8^Genomic ref allele^LN|2d|A|
-OBX|1093|NR|81254-5^Genomic allele start-end^LN|2d|60593|
-OBX|1094|ST|69551-0^Genomic alt allele^LN|2d|T|
-OBX|1095|ST|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
-OBX|1096|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
-OBX|1097|ST|69548-6^Genetic Variant Assessment^LN|2d|Present|
-OBX|1098|CNE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
-OBX|1099|ST|83005-9^Variant Category^LN|2e|Simple|
-OBX|1100|ST|47998-0^Variant Display Name^LN|2e|NC_000023.11:60691:T:C|
-OBX|1101|CWE|48018-6^Gene Studied^LN|2e|HGNC:0000^NoGene^HGNC|
-OBX|1102|ST|48004-6^DNA Change c.HGVS^LN|2e|NC_000023.11:60691:T:C|
-OBX|1103|ST|48013-7^Genomic reference sequence^LN|2e|NC_000023.11|
-OBX|1104|ST|69547-8^Genomic ref allele^LN|2e|T|
-OBX|1105|NR|81254-5^Genomic allele start-end^LN|2e|60692|
-OBX|1106|ST|69551-0^Genomic alt allele^LN|2e|C|
-OBX|1107|ST|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
-OBX|1108|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
-OBX|1109|ST|69548-6^Genetic Variant Assessment^LN|2e|Present|
-OBX|1110|CNE|53034-5^Allelic state^LN|2e|LA6706-1^Heterozygous^LN|
-OBX|1111|ST|83005-9^Variant Category^LN|2f|Simple|
-OBX|1112|ST|47998-0^Variant Display Name^LN|2f|NC_000023.11:60881:T:G|
-OBX|1113|CWE|48018-6^Gene Studied^LN|2f|HGNC:0000^NoGene^HGNC|
-OBX|1114|ST|48004-6^DNA Change c.HGVS^LN|2f|NC_000023.11:60881:T:G|
-OBX|1115|ST|48013-7^Genomic reference sequence^LN|2f|NC_000023.11|
-OBX|1116|ST|69547-8^Genomic ref allele^LN|2f|T|
-OBX|1117|NR|81254-5^Genomic allele start-end^LN|2f|60882|
-OBX|1118|ST|69551-0^Genomic alt allele^LN|2f|G|
-OBX|1119|ST|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
-OBX|1120|ST|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
-OBX|1121|ST|69548-6^Genetic Variant Assessment^LN|2f|Present|
-OBX|1122|CNE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|
+OBX|1059|ST|48000-4^Chromosome^LN|2a|X|
+OBX|1060|CWE|48002-0^Genomic Source Class [Type]^LN|2a|LA6683-2^Germline^LN|
+OBX|1061|CWE|81304-8^Variant Analysis Method [Type]^LN|2a|LA26398-0^Sequencing^LN|
+OBX|1062|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2a|not specified|
+OBX|1063|CWE|69548-6^Genetic Variant Assessment^LN|2a|LA9633-4^Present^LN|
+OBX|1064|CWE|53034-5^Allelic state^LN|2a|LA6706-1^Heterozygous^LN|
+OBX|1065|CWE|83005-9^Variant Category^LN|2b|LA26801-3^Simple^LN|
+OBX|1066|ST|47998-0^Variant Display Name^LN|2b|NC_000023.11:60578:G:A|
+OBX|1067|CWE|48018-6^Gene Studied^UFMOLLRR|2b|HGNC:0000^NoGene^HGNC|
+OBX|1068|CWE|48004-6^DNA Change c.HGVS^LN|2b|NC_000023.11:60578:G:A|
+OBX|1069|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2b|NC_000023.11|
+OBX|1070|ST|69547-8^Genomic ref allele^LN|2b|G|
+OBX|1071|NR|81254-5^Genomic allele start-end^LN|2b|60579|
+OBX|1072|ST|69551-0^Genomic alt allele^LN|2b|A|
+OBX|1073|ST|48000-4^Chromosome^LN|2b|X|
+OBX|1074|CWE|48002-0^Genomic Source Class [Type]^LN|2b|LA6683-2^Germline^LN|
+OBX|1075|CWE|81304-8^Variant Analysis Method [Type]^LN|2b|LA26398-0^Sequencing^LN|
+OBX|1076|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2b|not specified|
+OBX|1077|CWE|69548-6^Genetic Variant Assessment^LN|2b|LA9633-4^Present^LN|
+OBX|1078|CWE|53034-5^Allelic state^LN|2b|LA6706-1^Heterozygous^LN|
+OBX|1079|CWE|83005-9^Variant Category^LN|2c|LA26801-3^Simple^LN|
+OBX|1080|ST|47998-0^Variant Display Name^LN|2c|NC_000023.11:60582:G:C|
+OBX|1081|CWE|48018-6^Gene Studied^UFMOLLRR|2c|HGNC:0000^NoGene^HGNC|
+OBX|1082|CWE|48004-6^DNA Change c.HGVS^LN|2c|NC_000023.11:60582:G:C|
+OBX|1083|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2c|NC_000023.11|
+OBX|1084|ST|69547-8^Genomic ref allele^LN|2c|G|
+OBX|1085|NR|81254-5^Genomic allele start-end^LN|2c|60583|
+OBX|1086|ST|69551-0^Genomic alt allele^LN|2c|C|
+OBX|1087|ST|48000-4^Chromosome^LN|2c|X|
+OBX|1088|CWE|48002-0^Genomic Source Class [Type]^LN|2c|LA6683-2^Germline^LN|
+OBX|1089|CWE|81304-8^Variant Analysis Method [Type]^LN|2c|LA26398-0^Sequencing^LN|
+OBX|1090|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2c|not specified|
+OBX|1091|CWE|69548-6^Genetic Variant Assessment^LN|2c|LA9633-4^Present^LN|
+OBX|1092|CWE|53034-5^Allelic state^LN|2c|LA6706-1^Heterozygous^LN|
+OBX|1093|CWE|83005-9^Variant Category^LN|2d|LA26801-3^Simple^LN|
+OBX|1094|ST|47998-0^Variant Display Name^LN|2d|NC_000023.11:60592:A:T|
+OBX|1095|CWE|48018-6^Gene Studied^UFMOLLRR|2d|HGNC:0000^NoGene^HGNC|
+OBX|1096|CWE|48004-6^DNA Change c.HGVS^LN|2d|NC_000023.11:60592:A:T|
+OBX|1097|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2d|NC_000023.11|
+OBX|1098|ST|69547-8^Genomic ref allele^LN|2d|A|
+OBX|1099|NR|81254-5^Genomic allele start-end^LN|2d|60593|
+OBX|1100|ST|69551-0^Genomic alt allele^LN|2d|T|
+OBX|1101|ST|48000-4^Chromosome^LN|2d|X|
+OBX|1102|CWE|48002-0^Genomic Source Class [Type]^LN|2d|LA6683-2^Germline^LN|
+OBX|1103|CWE|81304-8^Variant Analysis Method [Type]^LN|2d|LA26398-0^Sequencing^LN|
+OBX|1104|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2d|not specified|
+OBX|1105|CWE|69548-6^Genetic Variant Assessment^LN|2d|LA9633-4^Present^LN|
+OBX|1106|CWE|53034-5^Allelic state^LN|2d|LA6706-1^Heterozygous^LN|
+OBX|1107|CWE|83005-9^Variant Category^LN|2e|LA26801-3^Simple^LN|
+OBX|1108|ST|47998-0^Variant Display Name^LN|2e|NC_000023.11:60691:T:C|
+OBX|1109|CWE|48018-6^Gene Studied^UFMOLLRR|2e|HGNC:0000^NoGene^HGNC|
+OBX|1110|CWE|48004-6^DNA Change c.HGVS^LN|2e|NC_000023.11:60691:T:C|
+OBX|1111|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2e|NC_000023.11|
+OBX|1112|ST|69547-8^Genomic ref allele^LN|2e|T|
+OBX|1113|NR|81254-5^Genomic allele start-end^LN|2e|60692|
+OBX|1114|ST|69551-0^Genomic alt allele^LN|2e|C|
+OBX|1115|ST|48000-4^Chromosome^LN|2e|X|
+OBX|1116|CWE|48002-0^Genomic Source Class [Type]^LN|2e|LA6683-2^Germline^LN|
+OBX|1117|CWE|81304-8^Variant Analysis Method [Type]^LN|2e|LA26398-0^Sequencing^LN|
+OBX|1118|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2e|not specified|
+OBX|1119|CWE|69548-6^Genetic Variant Assessment^LN|2e|LA9633-4^Present^LN|
+OBX|1120|CWE|53034-5^Allelic state^LN|2e|LA6706-1^Heterozygous^LN|
+OBX|1121|CWE|83005-9^Variant Category^LN|2f|LA26801-3^Simple^LN|
+OBX|1122|ST|47998-0^Variant Display Name^LN|2f|NC_000023.11:60881:T:G|
+OBX|1123|CWE|48018-6^Gene Studied^UFMOLLRR|2f|HGNC:0000^NoGene^HGNC|
+OBX|1124|CWE|48004-6^DNA Change c.HGVS^LN|2f|NC_000023.11:60881:T:G|
+OBX|1125|CWE|48013-7^Genomic reference sequence^UFMOLLRR|2f|NC_000023.11|
+OBX|1126|ST|69547-8^Genomic ref allele^LN|2f|T|
+OBX|1127|NR|81254-5^Genomic allele start-end^LN|2f|60882|
+OBX|1128|ST|69551-0^Genomic alt allele^LN|2f|G|
+OBX|1129|ST|48000-4^Chromosome^LN|2f|X|
+OBX|1130|CWE|48002-0^Genomic Source Class [Type]^LN|2f|LA6683-2^Germline^LN|
+OBX|1131|CWE|81304-8^Variant Analysis Method [Type]^LN|2f|LA26398-0^Sequencing^LN|
+OBX|1132|CWE|53037-8^Genetic Sequence Variation Clinical Significance^LN|2f|not specified|
+OBX|1133|CWE|69548-6^Genetic Variant Assessment^LN|2f|LA9633-4^Present^LN|
+OBX|1134|CWE|53034-5^Allelic state^LN|2f|LA6706-1^Heterozygous^LN|

--- a/vcf2hl7v2/test/test_integration.py
+++ b/vcf2hl7v2/test/test_integration.py
@@ -10,17 +10,13 @@ import filecmp
 suite = doctest.DocTestSuite(vcf2hl7v2)
 
 
-class TestVcf2HL7v2Inputs(unittest.TestCase):
+class Testvcf2hl7v2Inputs(unittest.TestCase):
 
-    def test_required_vcf_filename(self):
+    def test_required_filename(self):
         with self.assertRaises(Exception) as context:
             vcf2hl7v2.Converter()
         self.assertTrue(
-            'You must provide vcf_filename' in str(context.exception))
-
-    def test_invalid_vcf_filename(self):
-        self.assertRaises(FileNotFoundError,
-                          vcf2hl7v2.Converter, *['Hello', 'GRCh38'])
+            'You must provide a vcf or a xml file' in str(context.exception))
 
     def test_required_ref_build(self):
         with self.assertRaises(Exception) as context:
@@ -119,7 +115,8 @@ class TestTranslation(unittest.TestCase):
     def test_wo_patient_id(self):
         self.maxDiff = None
         o_vcf_2_hl7v2 = vcf2hl7v2.Converter(os.path.join(
-            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37')
+            os.path.dirname(__file__), 'vcf_example1.vcf'), 'GRCh37',
+            source_class='germline')
         output_filename = os.path.join(os.path.dirname(
             __file__), self.TEST_RESULT_DIR, 'hl7v2_wo_patient_example1.txt')
         expected_output_filename = os.path.join(
@@ -133,7 +130,8 @@ class TestTranslation(unittest.TestCase):
     def test_with_patient_id(self):
         self.maxDiff = None
         o_vcf_2_hl7v2 = vcf2hl7v2.Converter(os.path.join(os.path.dirname(
-            __file__), 'vcf_example1.vcf'), 'GRCh37', 'HG00628')
+            __file__), 'vcf_example1.vcf'), 'GRCh37', 'HG00628',
+            source_class='germline')
         output_filename = os.path.join(os.path.dirname(
             __file__), self.TEST_RESULT_DIR, 'hl7v2_with_patient_example1.txt')
         expected_output_filename = os.path.join(os.path.dirname(
@@ -161,7 +159,8 @@ class TestTranslation(unittest.TestCase):
             'GRCh38',
             'HG00628',
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
         self.assertEqual(
                 filecmp.cmp(output_filename, expected_output_filename),
@@ -188,7 +187,8 @@ class TestTranslation(unittest.TestCase):
             'GRCh38',
             'HG00628',
             conv_region_dict=conv_region_dict,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
         self.assertEqual(
                 filecmp.cmp(output_filename, expected_output_filename),
@@ -214,7 +214,8 @@ class TestTranslation(unittest.TestCase):
             'GRCh38',
             'HG00628',
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
         self.assertEqual(
                 filecmp.cmp(output_filename, expected_output_filename),
@@ -232,7 +233,8 @@ class TestTranslation(unittest.TestCase):
                 'vcf_example4.vcf'),
             'GRCh38',
             'HG00628',
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
 
     def test_empty_hl7v2_txt(self):
@@ -246,7 +248,8 @@ class TestTranslation(unittest.TestCase):
                 'vcf_example4.vcf'),
             'GRCh38',
             'HG00628',
-            conv_region_filename=conv_region_filename)
+            conv_region_filename=conv_region_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
 
     def test_tabix(self):
@@ -267,7 +270,8 @@ class TestTranslation(unittest.TestCase):
             'HG00628',
             has_tabix=True,
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
         self.assertEqual(
                 filecmp.cmp(output_filename, expected_output_filename),
@@ -276,7 +280,7 @@ class TestTranslation(unittest.TestCase):
 
     def test_annotation(self):
         o_vcf_2_hl7v2 = vcf2hl7v2.Converter(
-                vcf_filename=os.path.join(
+                filename=os.path.join(
                                         os.path.dirname(__file__),
                                         'NB6TK328_filtered.vcf'
                                     ),
@@ -309,6 +313,38 @@ class TestTranslation(unittest.TestCase):
                 filecmp.cmp(output_filename, expected_output_filename),
                 True
             )
+
+    # def test_qci_xml(self):
+    #     output_filename = os.path.join(os.path.dirname(
+    #         __file__), self.TEST_RESULT_DIR, 'qci_hl7v2.txt')
+    #     expected_output_filename = os.path.join(
+    #         os.path.dirname(__file__), 'expected_qci_xml.txt')
+    #     o_vcf_2_hl7v2 = vcf2hl7v2.Converter(
+    #         filename=os.path.join(os.path.dirname(__file__), 'QCI.xml'),
+    #         ref_build='GRCh37',
+    #         patient_id='HG00628',
+    #         source_class='somatic')
+    #     o_vcf_2_hl7v2.convert(output_filename)
+    #     self.assertEqual(
+    #             filecmp.cmp(output_filename, expected_output_filename),
+    #             True
+    #         )
+
+    # def test_qiagen_vcf(self):
+    #     output_filename = os.path.join(os.path.dirname(
+    #         __file__), self.TEST_RESULT_DIR, 'qiagen_vcf_hl7v2.txt')
+    #     expected_output_filename = os.path.join(
+    #         os.path.dirname(__file__), 'expected_qiagen_vcf.txt')
+    #     o_vcf_2_hl7v2 = vcf2hl7v2.Converter(
+    #         filename=os.path.join(os.path.dirname(__file__), 'qiagen.vcf'),
+    #         ref_build='GRCh37',
+    #         vcf_type='QiaGen',
+    #         source_class='germline')
+    #     o_vcf_2_hl7v2.convert(output_filename)
+    #     self.assertEqual(
+    #             filecmp.cmp(output_filename, expected_output_filename),
+    #             True
+    #         )
 
 
 class TestLogger(unittest.TestCase):
@@ -369,7 +405,8 @@ class TestLogger(unittest.TestCase):
             'GRCh38',
             'HG00628',
             conv_region_filename=conv_region_filename,
-            region_studied_filename=region_studied_filename)
+            region_studied_filename=region_studied_filename,
+            source_class='germline')
         o_vcf_2_hl7v2.convert(output_filename)
         self.assertEqual(os.path.exists(self.log_general_filename), True)
         self.assertEqual(os.path.exists(
@@ -377,7 +414,7 @@ class TestLogger(unittest.TestCase):
 
 
 suite.addTests(
-    unittest.TestLoader().loadTestsFromTestCase(TestVcf2HL7v2Inputs))
+    unittest.TestLoader().loadTestsFromTestCase(Testvcf2hl7v2Inputs))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestTranslation))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestLogger))
 


### PR DESCRIPTION
## Description

- Adds support for conversion of `QCI XML` file
- Adds support for conversion of `Qiagen` and `SnpEFF` vcf
- Adds a new parameter, `variant_analysis_method`
- Adds a new parameter, `report_filename`

## How Has This Been Tested?

The code has been tested by running all the unit tests using the command `python -m unittest` and the **PEP 8** formatting was validated using `pycodestyle`.

- [x] Unit Tests
- [x] PEP 8 Formatting Validation
